### PR TITLE
[fix] crop_gdd_daily upsert 컬럼명 crop_id -> crops_id 수정

### DIFF
--- a/src/main/java/com/example/practice/repository/crops/CropGddDailyRepository.java
+++ b/src/main/java/com/example/practice/repository/crops/CropGddDailyRepository.java
@@ -32,18 +32,18 @@ public interface CropGddDailyRepository extends JpaRepository<CropGddDaily, Long
                                            @Param("to") LocalDate to);
 
     /**
-     * Postgres UPSERT (crop_id + target_date 유니크 제약 필요)
+     * Postgres UPSERT (crops_id + target_date 유니크 제약 필요)
      */
     @Modifying
     @Transactional
-    @Query(value = """
+        @Query(value = """
         INSERT INTO crop_gdd_daily
-        (crop_id, target_date, gdd, gdd_normal_5y, base_temp,
+        (crops_id, target_date, gdd, gdd_normal_5y, base_temp,
          station_type, station_code, source, fetched_at, created_at, updated_at)
         VALUES
         (:cropId, :targetDate, :gdd, :gddNormal5y, :baseTemp,
          :stationType, :stationCode, :source, :fetchedAt, now(), now())
-        ON CONFLICT (crop_id, target_date)
+        ON CONFLICT (crops_id, target_date)
         DO UPDATE SET
             gdd = EXCLUDED.gdd,
             gdd_normal_5y = EXCLUDED.gdd_normal_5y,


### PR DESCRIPTION
#3 

## 배경
`crop_gdd_daily` 테이블의 FK 컬럼은 `crops_id`인데,  
GDD 적재 native upsert 쿼리에서 `crop_id`를 사용하고 있어 실행 실패 가능성이 있음

## 변경 사항
- `CropGddDailyRepository.upsert` native query 수정
  - `INSERT INTO crop_gdd_daily (crop_id, ...)` -> `INSERT INTO crop_gdd_daily (crops_id, ...)`
  - `ON CONFLICT (crop_id, target_date)` -> `ON CONFLICT (crops_id, target_date)`

## 영향도
- GDD 적재(`refresh`, 스케줄러) 시 upsert SQL이 실제 스키마와 일치
- 기존 조회 API 동작에는 영향 없음
