### PR TITLE
[release] dev -> main 배포 (Swagger farms 경로 노출 수정 포함)

### DIFF
--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -49,7 +49,7 @@ springdoc:
     path: /swagger-ui.html
   api-docs:
     path: /v3/api-docs
-  paths-to-match: /auth/**,/users/**,/farms/**,/api/v1/crops/**
+  paths-to-match: /auth/**,/users/**,/farms/**,/api/v1/crops/**,/api/v1/farms/**
 
 swagger:
   server-url: ${SWAGGER_SERVER_URL:http://localhost:8080}


### PR DESCRIPTION
## 변경 내용
- Swagger 노출 경로 설정 수정
- `application-dev.yml`의 `springdoc.paths-to-match`에 `/api/v1/farms/**` 추가
- 기존 `/api/v1/crops/**`만 보이던 문제 해결

## 영향도
- 문서 노출 범위 설정 변경만 포함 (비즈니스 로직 변경 없음)
