### PR TITLE
[feat] 병해충 분석 응답을 DB 기반(원인/증상/해결)으로 확장하고 vision-inference 구조 개선

### DIFF
--- a/docs/ai-response-mapping.md
+++ b/docs/ai-response-mapping.md
@@ -50,19 +50,22 @@
 
 ## 3) Farm-Us API 응답 계약 (BE -> Client)
 
-`/api/v1/farms/{farmId}/crops/{cropsId}/vision/infer`는 `VisionInferenceResponse`를 반환합니다.
+`/api/v1/farms/{farmId}/crops/{cropsId}/vision-inference`는 `VisionInferenceCheckResponse`를 반환합니다.
 
 ```json
 {
-  "captureId": 1,
-  "inferenceId": 1,
-  "disease": "a7",
-  "confidence": 0.91,
-  "abnormal": true,
-  "abnormalReason": "low_confidence",
-  "modelName": "kimphys-62-a",
-  "modelVersion": "v2.0",
-  "inferredAt": "2026-03-01T10:00:00Z"
+  "success": true,
+  "code": "200",
+  "data": {
+    "diseaseStatus": 1,
+    "diseaseId": "a7",
+    "diseaseName": "잎마름병",
+    "diseaseDescription": "잎 가장자리부터 갈변하며 진행되면 잎 전체가 마를 수 있습니다.",
+    "confidence": 91,
+    "causes": ["..."],
+    "symptoms": ["..."],
+    "solutions": ["..."]
+  }
 }
 ```
 

--- a/docs/sql/disease_info_seed.sql
+++ b/docs/sql/disease_info_seed.sql
@@ -1,0 +1,59 @@
+CREATE TABLE IF NOT EXISTS disease_info (
+    disease_id VARCHAR(50) PRIMARY KEY,
+    disease_name VARCHAR(120) NOT NULL,
+    disease_description TEXT,
+    active BOOLEAN NOT NULL DEFAULT TRUE
+);
+
+CREATE TABLE IF NOT EXISTS disease_guide (
+    guide_id BIGSERIAL PRIMARY KEY,
+    disease_id VARCHAR(50) NOT NULL REFERENCES disease_info(disease_id),
+    guide_type VARCHAR(20) NOT NULL,
+    content TEXT NOT NULL,
+    sort_order INT
+);
+
+CREATE INDEX IF NOT EXISTS idx_disease_guide_disease_id ON disease_guide(disease_id);
+CREATE INDEX IF NOT EXISTS idx_disease_guide_type ON disease_guide(guide_type);
+
+INSERT INTO disease_info (disease_id, disease_name, disease_description, active) VALUES
+('a7', '잎마름병', '잎 가장자리부터 갈변하며 진행되면 잎 전체가 마를 수 있습니다.', TRUE),
+('a3', '흰가루병', '잎 표면에 흰가루가 퍼지며 광합성을 저해하는 병입니다.', TRUE),
+('a5', '녹병', '잎 뒷면에 녹슨 가루 형태의 포자가 생기는 곰팡이성 병해입니다.', TRUE)
+ON CONFLICT (disease_id) DO UPDATE SET
+    disease_name = EXCLUDED.disease_name,
+    disease_description = EXCLUDED.disease_description,
+    active = EXCLUDED.active;
+
+DELETE FROM disease_guide WHERE disease_id IN ('a7', 'a3', 'a5');
+
+INSERT INTO disease_guide (disease_id, guide_type, content, sort_order) VALUES
+('a7', 'CAUSE', '고온다습한 환경이 오래 지속될 때 발생하기 쉽습니다.', 1),
+('a7', 'CAUSE', '통풍이 부족하고 잎 표면이 젖은 상태가 길어질 때 확산됩니다.', 2),
+('a7', 'CAUSE', '감염된 잔재물이 남아 있을 경우 재발 가능성이 높습니다.', 3),
+('a7', 'SYMPTOM', '잎 가장자리에 황갈색 반점이 생기고 점차 넓어집니다.', 1),
+('a7', 'SYMPTOM', '병반 주변이 노랗게 변색되고 마르는 증상이 나타납니다.', 2),
+('a7', 'SYMPTOM', '심해지면 생육이 저하되고 수확량이 감소합니다.', 3),
+('a7', 'SOLUTION', '감염된 잎은 즉시 제거하고 재배지 밖으로 폐기합니다.', 1),
+('a7', 'SOLUTION', '재배 밀도를 낮추고 환기를 개선해 잎의 건조 시간을 확보합니다.', 2),
+('a7', 'SOLUTION', '병해 등록 약제를 사용 지침에 따라 살포하고 주기적으로 모니터링합니다.', 3),
+
+('a3', 'CAUSE', '일교차가 크고 습도가 높을 때 발병 위험이 증가합니다.', 1),
+('a3', 'CAUSE', '밀식 재배로 통풍이 나쁘면 병원균이 빠르게 퍼질 수 있습니다.', 2),
+('a3', 'CAUSE', '질소 과다 시비는 연약한 조직을 만들어 감염 위험을 높입니다.', 3),
+('a3', 'SYMPTOM', '잎에 하얀 가루 형태의 병반이 나타납니다.', 1),
+('a3', 'SYMPTOM', '진행되면 잎이 누렇게 변하고 말리며 낙엽이 늘어납니다.', 2),
+('a3', 'SYMPTOM', '신초 생장이 둔화되고 전반적인 초세가 약해집니다.', 3),
+('a3', 'SOLUTION', '감염 부위를 제거해 초기 전염원을 줄입니다.', 1),
+('a3', 'SOLUTION', '환기와 일조를 확보하고 과습을 피합니다.', 2),
+('a3', 'SOLUTION', '작물과 시기에 맞는 흰가루병 방제제를 교호 살포합니다.', 3),
+
+('a5', 'CAUSE', '장기간의 높은 습도와 잎 젖음 시간이 주요 원인입니다.', 1),
+('a5', 'CAUSE', '질소 과다와 밀식 재배는 발병을 촉진할 수 있습니다.', 2),
+('a5', 'CAUSE', '병든 잔재물 관리가 미흡하면 다음 작기 전염원이 됩니다.', 3),
+('a5', 'SYMPTOM', '잎 뒷면에 주황색 또는 갈색 포자 무리가 형성됩니다.', 1),
+('a5', 'SYMPTOM', '병반이 확대되면서 잎의 황화와 조기 낙엽이 나타납니다.', 2),
+('a5', 'SYMPTOM', '광합성 저하로 생육 정체 및 품질 저하가 발생합니다.', 3),
+('a5', 'SOLUTION', '초기 감염 잎을 제거해 전파를 차단합니다.', 1),
+('a5', 'SOLUTION', '관수 시간을 조절해 잎 젖음 시간을 줄이고 통풍을 개선합니다.', 2),
+('a5', 'SOLUTION', '등록 약제를 예방 및 초기 단계에서 사용합니다.', 3);

--- a/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
+++ b/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
@@ -1,7 +1,7 @@
 package com.example.practice.controller.crops;
 
 import com.example.practice.common.config.TokenAuthFilter;
-import com.example.practice.dto.crops.VisionInferenceResponse;
+import com.example.practice.dto.crops.VisionInferenceCheckResponse;
 import com.example.practice.service.crops.VisionInferenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -37,7 +37,7 @@ public class FarmCropVisionController {
             @ApiResponse(responseCode = "504", description = "AI 서버 타임아웃")
     })
     @PostMapping("/{farmId}/crops/{cropsId}/vision-inference")
-    public VisionInferenceResponse infer(
+    public VisionInferenceCheckResponse infer(
             @PathVariable Long farmId,
             @PathVariable Long cropsId,
             @RequestParam("image") MultipartFile image,

--- a/src/main/java/com/example/practice/dto/crops/DiseaseCheckData.java
+++ b/src/main/java/com/example/practice/dto/crops/DiseaseCheckData.java
@@ -1,0 +1,37 @@
+package com.example.practice.dto.crops;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Schema(description = "병해충 분석 상세 데이터")
+public record DiseaseCheckData(
+        @Schema(description = "질병 감지 여부(0: 정상, 1: 질병)", example = "1")
+        int diseaseStatus,
+        @Schema(description = "질병 코드", example = "a7")
+        String diseaseId,
+        @Schema(description = "질병명", example = "잎마름병")
+        String diseaseName,
+        @Schema(description = "질병 설명", example = "잎 가장자리부터 갈변하며 점차 확산됩니다.")
+        String diseaseDescription,
+        @Schema(description = "신뢰도(0~100)", example = "99")
+        int confidence,
+        @Schema(description = "발생 원인 목록")
+        List<String> causes,
+        @Schema(description = "대표 증상 목록")
+        List<String> symptoms,
+        @Schema(description = "해결/관리 방법 목록")
+        List<String> solutions,
+        @Schema(description = "업로드 이미지 ID", example = "3")
+        Long uploadedImageId,
+        @Schema(description = "추론 ID", example = "1")
+        Long inferenceId,
+        @Schema(description = "모델명", example = "farmus-placeholder-model")
+        String modelName,
+        @Schema(description = "모델 버전", example = "v0.1.0")
+        String modelVersion,
+        @Schema(description = "추론 시각(UTC)")
+        OffsetDateTime inferredAt
+) {
+}

--- a/src/main/java/com/example/practice/dto/crops/VisionInferenceCheckResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/VisionInferenceCheckResponse.java
@@ -1,0 +1,17 @@
+package com.example.practice.dto.crops;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "병해충 분석 응답")
+public record VisionInferenceCheckResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+        @Schema(description = "응답 코드", example = "200")
+        String code,
+        @Schema(description = "병해충 분석 데이터")
+        DiseaseCheckData data
+) {
+    public static VisionInferenceCheckResponse ok(DiseaseCheckData data) {
+        return new VisionInferenceCheckResponse(true, "200", data);
+    }
+}

--- a/src/main/java/com/example/practice/entity/crops/DiseaseGuide.java
+++ b/src/main/java/com/example/practice/entity/crops/DiseaseGuide.java
@@ -1,0 +1,41 @@
+package com.example.practice.entity.crops;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "disease_guide")
+public class DiseaseGuide {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "guide_id")
+    private Long guideId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "disease_id", nullable = false)
+    private DiseaseInfo diseaseInfo;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "guide_type", nullable = false, length = 20)
+    private DiseaseGuideType guideType;
+
+    @Column(name = "content", nullable = false, columnDefinition = "text")
+    private String content;
+
+    @Column(name = "sort_order")
+    private Integer sortOrder;
+}

--- a/src/main/java/com/example/practice/entity/crops/DiseaseGuideType.java
+++ b/src/main/java/com/example/practice/entity/crops/DiseaseGuideType.java
@@ -1,0 +1,7 @@
+package com.example.practice.entity.crops;
+
+public enum DiseaseGuideType {
+    CAUSE,
+    SYMPTOM,
+    SOLUTION
+}

--- a/src/main/java/com/example/practice/entity/crops/DiseaseInfo.java
+++ b/src/main/java/com/example/practice/entity/crops/DiseaseInfo.java
@@ -1,0 +1,37 @@
+package com.example.practice.entity.crops;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Setter
+@Entity
+@Table(name = "disease_info")
+public class DiseaseInfo {
+
+    @Id
+    @Column(name = "disease_id", length = 50)
+    private String diseaseId;
+
+    @Column(name = "disease_name", nullable = false, length = 120)
+    private String diseaseName;
+
+    @Column(name = "disease_description", columnDefinition = "text")
+    private String diseaseDescription;
+
+    @Column(name = "active", nullable = false)
+    private Boolean active = true;
+
+    @OneToMany(mappedBy = "diseaseInfo", fetch = FetchType.LAZY, cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DiseaseGuide> guides = new ArrayList<>();
+}

--- a/src/main/java/com/example/practice/repository/crops/DiseaseInfoRepository.java
+++ b/src/main/java/com/example/practice/repository/crops/DiseaseInfoRepository.java
@@ -1,0 +1,13 @@
+package com.example.practice.repository.crops;
+
+import com.example.practice.entity.crops.DiseaseInfo;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface DiseaseInfoRepository extends JpaRepository<DiseaseInfo, String> {
+
+    @EntityGraph(attributePaths = "guides")
+    Optional<DiseaseInfo> findByDiseaseIdAndActiveTrue(String diseaseId);
+}

--- a/src/main/java/com/example/practice/service/aws/AwsS3Service.java
+++ b/src/main/java/com/example/practice/service/aws/AwsS3Service.java
@@ -8,6 +8,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.UUID;
 
@@ -26,25 +27,27 @@ public class AwsS3Service {
         }
 
         try {
-            String originalFilename = file.getOriginalFilename();
-            if (originalFilename == null || originalFilename.isBlank()) {
-                originalFilename = "file";
-            }
-            String fileName = UUID.randomUUID() + "_" + originalFilename;
-            String key = dirName + "/" + fileName;  // farm/uuid_filename.png
-
-            ObjectMetadata metadata = new ObjectMetadata();
-            metadata.setContentLength(file.getSize());
-            metadata.setContentType(file.getContentType());
-
-            amazonS3.putObject(new PutObjectRequest(bucket, key, file.getInputStream(), metadata));
-
-            // 퍼블릭 URL 리턴
-            return amazonS3.getUrl(bucket, key).toString();
+            return upload(file.getBytes(), file.getOriginalFilename(), file.getContentType(), dirName);
 
         } catch (IOException e) {
             throw new RuntimeException("S3 업로드 실패", e);
         }
     }
-}
 
+    public String upload(byte[] bytes, String originalFilename, String contentType, String dirName) {
+        if (bytes == null || bytes.length == 0) {
+            return null;
+        }
+
+        String safeOriginalName = (originalFilename == null || originalFilename.isBlank()) ? "file" : originalFilename;
+        String fileName = UUID.randomUUID() + "_" + safeOriginalName;
+        String key = dirName + "/" + fileName;
+
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentLength(bytes.length);
+        metadata.setContentType(contentType);
+
+        amazonS3.putObject(new PutObjectRequest(bucket, key, new ByteArrayInputStream(bytes), metadata));
+        return amazonS3.getUrl(bucket, key).toString();
+    }
+}

--- a/src/main/java/com/example/practice/service/crops/GddSummaryService.java
+++ b/src/main/java/com/example/practice/service/crops/GddSummaryService.java
@@ -30,6 +30,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Locale;
 import java.util.Map;
 import com.example.practice.dto.crops.GrowthDiaryCardResponse;
 
@@ -262,7 +263,7 @@ public class GddSummaryService {
             diseaseName = "unknown";
         }
 
-        String status = "healthy".equalsIgnoreCase(diseaseName) ? "NORMAL" : "ABNORMAL";
+        String status = isHealthyLike(diseaseName) ? "NORMAL" : "ABNORMAL";
         return new DiseaseLatestResponse(status, diseaseName, latest.getAiConfidence(), latest.getMeasuredAt());
     }
 
@@ -307,6 +308,17 @@ public class GddSummaryService {
         }
         String trimmed = value.trim();
         return trimmed.isEmpty() ? null : trimmed;
+    }
+
+    private boolean isHealthyLike(String diseaseName) {
+        if (diseaseName == null) {
+            return true;
+        }
+        String normalized = diseaseName.trim().toLowerCase(Locale.ROOT);
+        return "healthy".equals(normalized)
+                || "normal".equals(normalized)
+                || "00".equals(normalized)
+                || "unknown".equals(normalized);
     }
 
     private Integer diffInt(Integer current, Integer previous) {

--- a/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
+++ b/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
@@ -2,16 +2,22 @@ package com.example.practice.service.crops;
 
 import com.example.practice.common.error.AppException;
 import com.example.practice.dto.crops.AiPredictResponse;
-import com.example.practice.dto.crops.VisionInferenceResponse;
+import com.example.practice.dto.crops.DiseaseCheckData;
+import com.example.practice.dto.crops.VisionInferenceCheckResponse;
 import com.example.practice.entity.crops.Crops;
+import com.example.practice.entity.crops.DiseaseGuide;
+import com.example.practice.entity.crops.DiseaseGuideType;
+import com.example.practice.entity.crops.DiseaseInfo;
 import com.example.practice.entity.crops.GrowthMeasurement;
 import com.example.practice.entity.crops.ImageCapture;
 import com.example.practice.entity.crops.VisionInference;
 import com.example.practice.repository.crops.CropsRepository;
+import com.example.practice.repository.crops.DiseaseInfoRepository;
 import com.example.practice.repository.crops.GrowthMeasurementRepository;
 import com.example.practice.repository.crops.ImageCaptureRepository;
 import com.example.practice.repository.crops.VisionInferenceRepository;
 import com.example.practice.repository.farm.FarmMemberRepository;
+import com.example.practice.service.aws.AwsS3Service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -37,8 +43,11 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -49,6 +58,8 @@ public class VisionInferenceService {
     private final ImageCaptureRepository imageCaptureRepository;
     private final VisionInferenceRepository visionInferenceRepository;
     private final GrowthMeasurementRepository growthMeasurementRepository;
+    private final DiseaseInfoRepository diseaseInfoRepository;
+    private final AwsS3Service awsS3Service;
     private final WebClient.Builder webClientBuilder;
     private final ObjectMapper objectMapper;
 
@@ -64,8 +75,14 @@ public class VisionInferenceService {
     @Value("${ai.inference.timeout-ms:5000}")
     private long aiTimeoutMs;
 
+    private static final Map<String, String> DISEASE_CODE_ALIASES = Map.of(
+            "leaf_blight", "a7",
+            "powdery_mildew", "a3",
+            "rust", "a5"
+    );
+
     @Transactional
-    public VisionInferenceResponse inferAndSave(
+    public VisionInferenceCheckResponse inferAndSave(
             Long farmId,
             Long cropsId,
             Long userId,
@@ -90,17 +107,17 @@ public class VisionInferenceService {
         String contentType = image.getContentType();
 
         OffsetDateTime capturedAt = measuredAt == null ? OffsetDateTime.now(ZoneOffset.UTC) : measuredAt;
-        ImageCapture capture = new ImageCapture();
-        capture.setCapturedAt(capturedAt);
-        capture.setCameraId(cameraId);
-        capture.setImagePath(saveCaptureImage(imageBytes, originalFilename));
-        capture = imageCaptureRepository.save(capture);
+        ImageCapture uploadedImage = new ImageCapture();
+        uploadedImage.setCapturedAt(capturedAt);
+        uploadedImage.setCameraId(cameraId);
+        uploadedImage.setImagePath(uploadUploadedImage(imageBytes, originalFilename, contentType));
+        uploadedImage = imageCaptureRepository.save(uploadedImage);
 
         String requestedTaskType = (taskType == null || taskType.isBlank()) ? "DISEASE_CLASSIFICATION" : taskType;
-        AiPredictResponse aiResponse = callAiServer(imageBytes, originalFilename, contentType, capture.getCaptureId(), requestedTaskType);
+        AiPredictResponse aiResponse = callAiServer(imageBytes, originalFilename, contentType, uploadedImage.getCaptureId(), requestedTaskType);
 
         VisionInference inference = new VisionInference();
-        inference.setCapture(capture);
+        inference.setCapture(uploadedImage);
         inference.setModelName(aiResponse.modelName());
         inference.setTaskType(aiResponse.taskType());
         inference.setLabel(aiResponse.label());
@@ -128,13 +145,59 @@ public class VisionInferenceService {
         measurement.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
         growthMeasurementRepository.save(measurement);
 
-        return new VisionInferenceResponse(
-                capture.getCaptureId(),
+        DiseaseCheckData data = toCheckData(uploadedImage, inference, aiResponse);
+        return VisionInferenceCheckResponse.ok(
+                data
+        );
+    }
+
+    private DiseaseCheckData toCheckData(ImageCapture uploadedImage, VisionInference inference, AiPredictResponse aiResponse) {
+        String normalizedDisease = normalizeDiseaseKey(aiResponse.disease(), aiResponse.label());
+        int diseaseStatus = isHealthyLike(normalizedDisease) ? 0 : 1;
+        int confidencePercent = toPercent(aiResponse.confidence());
+
+        if (diseaseStatus == 0) {
+            return new DiseaseCheckData(
+                    0,
+                    "healthy",
+                    "정상",
+                    "현재 병해충 징후가 뚜렷하지 않습니다.",
+                    confidencePercent,
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    uploadedImage.getCaptureId(),
+                    inference.getInferenceId(),
+                    aiResponse.modelName(),
+                    aiResponse.modelVersion(),
+                    aiResponse.inferredAt()
+            );
+        }
+
+        DiseaseInfo info = diseaseInfoRepository.findByDiseaseIdAndActiveTrue(normalizedDisease).orElse(null);
+        List<String> causes = guideList(info, DiseaseGuideType.CAUSE);
+        List<String> symptoms = guideList(info, DiseaseGuideType.SYMPTOM);
+        List<String> solutions = guideList(info, DiseaseGuideType.SOLUTION);
+        String diseaseId = info != null ? info.getDiseaseId() : normalizedDisease;
+        String diseaseName = info != null ? info.getDiseaseName() : "질병 미확정";
+        String diseaseDescription = info != null
+                ? safeText(info.getDiseaseDescription())
+                : "해당 질병 코드에 대한 설명 데이터가 등록되지 않았습니다.";
+        if (diseaseDescription == null) {
+            diseaseDescription = "해당 질병 코드에 대한 설명 데이터가 등록되지 않았습니다.";
+        }
+
+        return new DiseaseCheckData(
+                1,
+                diseaseId,
+                diseaseName,
+                diseaseDescription,
+                confidencePercent,
+                causes,
+                symptoms,
+                solutions,
+                uploadedImage.getCaptureId(),
                 inference.getInferenceId(),
-                aiResponse.disease(),
-                aiResponse.confidence(),
-                aiResponse.isAbnormal(),
-                aiResponse.abnormalReason(),
                 aiResponse.modelName(),
                 aiResponse.modelVersion(),
                 aiResponse.inferredAt()
@@ -264,11 +327,68 @@ public class VisionInferenceService {
         if (abnormalReason != null && !abnormalReason.isBlank()) {
             return true;
         }
+        return !isHealthyLike(disease);
+    }
+
+    private boolean isHealthyLike(String disease) {
         if (disease == null) {
-            return false;
+            return true;
         }
-        String normalized = disease.trim().toLowerCase();
-        return !("00".equals(normalized) || "healthy".equals(normalized) || "normal".equals(normalized));
+        String normalized = disease.trim().toLowerCase(Locale.ROOT);
+        return "00".equals(normalized)
+                || "healthy".equals(normalized)
+                || "normal".equals(normalized)
+                || "unknown".equals(normalized);
+    }
+
+    private int toPercent(BigDecimal confidence) {
+        if (confidence == null) {
+            return 0;
+        }
+        BigDecimal multiplied = confidence.multiply(BigDecimal.valueOf(100));
+        return multiplied.setScale(0, java.math.RoundingMode.HALF_UP).intValue();
+    }
+
+    private String normalizeDiseaseKey(String disease, String label) {
+        String key = firstNonBlank(disease, label, "unknown");
+        String normalized = key.toLowerCase(Locale.ROOT);
+        return DISEASE_CODE_ALIASES.getOrDefault(normalized, normalized);
+    }
+
+    private String uploadUploadedImage(byte[] imageBytes, String originalFilename, String contentType) {
+        try {
+            String uploadedUrl = awsS3Service.upload(imageBytes, originalFilename, contentType, "captures");
+            if (uploadedUrl != null && !uploadedUrl.isBlank()) {
+                return uploadedUrl;
+            }
+        } catch (RuntimeException ignored) {
+            // S3 설정이 없는 로컬 환경에서는 기존 로컬 저장 경로로 fallback.
+        }
+        return saveCaptureImage(imageBytes, originalFilename);
+    }
+
+    private List<String> guideList(DiseaseInfo info, DiseaseGuideType guideType) {
+        if (info == null || info.getGuides() == null) {
+            return List.of();
+        }
+        return info.getGuides().stream()
+                .filter(guide -> guide != null && guideType.equals(guide.getGuideType()))
+                .sorted((a, b) -> Integer.compare(
+                        a.getSortOrder() == null ? Integer.MAX_VALUE : a.getSortOrder(),
+                        b.getSortOrder() == null ? Integer.MAX_VALUE : b.getSortOrder()
+                ))
+                .map(DiseaseGuide::getContent)
+                .map(this::safeText)
+                .filter(value -> value != null)
+                .collect(Collectors.toList());
+    }
+
+    private String safeText(String value) {
+        if (value == null) {
+            return null;
+        }
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
     }
 
     private BigDecimal top1Probability(List<AiPredictResponse.TopKItem> top3) {


### PR DESCRIPTION
# 작업 내용
- vision-inference 응답 스키마를 success/code/data 래핑 구조로 변경
- 질병 판별 결과와 함께 질병 상세 가이드(원인/증상/해결)를 제공하도록 API 확장
- 질병 가이드를 코드 상수에서 제거하고 DB(disease_info, disease_guide)에서 동적 조회하도록 전환