### PR TITLE
[feat] 생장 추론 API 분리 및 AI 연동 구조 개선

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -117,7 +117,7 @@ jobs:
                   - /home/${USERNAME}/kimphys_api_a/app.py:/workspace/app.py:ro
                   - /home/${USERNAME}/kimphys_api_a/models:/workspace/models:ro
                 command: >
-                  bash -lc "pip install -q ujson fastapi uvicorn python-multipart &&
+                  bash -lc "pip uninstall -y opencv-python >/dev/null 2>&1 || true; pip install -q ujson fastapi uvicorn python-multipart ultralytics opencv-python-headless &&
                   uvicorn app:app --host 0.0.0.0 --port 8001 --app-dir /workspace"
                 restart: unless-stopped
             EOF

--- a/deploy/docker-compose.server.template.yml
+++ b/deploy/docker-compose.server.template.yml
@@ -33,6 +33,6 @@ services:
       - /home/${USERNAME}/kimphys_api_a/app.py:/workspace/app.py:ro
       - /home/${USERNAME}/kimphys_api_a/models:/workspace/models:ro
     command: >
-      bash -lc "pip install -q ujson fastapi uvicorn python-multipart &&
+      bash -lc "pip uninstall -y opencv-python >/dev/null 2>&1 || true; pip install -q ujson fastapi uvicorn python-multipart ultralytics opencv-python-headless &&
       uvicorn app:app --host 0.0.0.0 --port 8001 --app-dir /workspace"
     restart: unless-stopped

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -17,6 +17,19 @@ services:
       timeout: 5s
       retries: 10
 
+  ai-inference-a:
+    profiles: ["ai"]
+    image: ${AI_A_IMAGE:-kimphys/62_a:v2.0}
+    container_name: kimphys-api-a-local
+    restart: unless-stopped
+    ports:
+      - "8001:8001"
+    volumes:
+      - ${LOCAL_AI_APP_PATH:-/tmp/kimphys_api_a/app.py}:/workspace/app.py:ro
+      - ${LOCAL_AI_MODELS_PATH:-/tmp/kimphys_api_a/models}:/workspace/models:ro
+    command: >
+      bash -lc "pip uninstall -y opencv-python >/dev/null 2>&1 || true; pip install -q ujson fastapi uvicorn python-multipart ultralytics opencv-python-headless &&
+      uvicorn app:app --host 0.0.0.0 --port 8001 --app-dir /workspace"
 
 volumes:
   farmus-postgres-data:

--- a/docs/ai-response-mapping.md
+++ b/docs/ai-response-mapping.md
@@ -57,7 +57,8 @@
 
 ## 3) Farm-Us API 응답 계약 (BE -> Client)
 
-`/api/v1/farms/{farmId}/crops/{cropsId}/vision-inference`는 `VisionInferenceCheckResponse`를 반환합니다.
+`/api/v1/farms/{farmId}/crops/{cropsId}/vision-inference`(병해충)와
+`/api/v1/farms/{farmId}/crops/{cropsId}/growth-inference`(생장)는 `VisionInferenceCheckResponse`를 반환합니다.
 
 ```json
 {

--- a/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
+++ b/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
@@ -1,11 +1,11 @@
 package com.example.practice.controller.crops;
 
 import com.example.practice.common.config.TokenAuthFilter;
+import com.example.practice.dto.crops.GrowthInferenceCheckResponse;
 import com.example.practice.dto.crops.VisionInferenceCheckResponse;
 import com.example.practice.service.crops.VisionInferenceService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -31,7 +31,7 @@ public class FarmCropVisionController {
 
     private final VisionInferenceService visionInferenceService;
 
-    @Operation(summary = "작물 이미지 AI 추론", description = "이미지를 AI 서버로 전달해 병해 추론 후 DB에 저장합니다.")
+    @Operation(summary = "작물 이미지 병해충 추론", description = "이미지를 AI 서버로 전달해 병해충 추론 후 DB에 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "추론 및 저장 성공"),
             @ApiResponse(responseCode = "502", description = "AI 서버 응답 오류"),
@@ -44,26 +44,44 @@ public class FarmCropVisionController {
             @PathVariable Long cropsId,
             @RequestParam("image") MultipartFile image,
             @RequestParam(required = false) Long cameraId,
-            @Parameter(
-                    description = "추론 태스크 타입",
-                    schema = @Schema(
-                            allowableValues = {"DISEASE_CLASSIFICATION", "GROWTH_MEASUREMENT"},
-                            defaultValue = "DISEASE_CLASSIFICATION"
-                    )
-            )
-            @RequestParam(required = false, defaultValue = "DISEASE_CLASSIFICATION") String taskType,
-            @Parameter(description = "작물 코드(숫자). GROWTH_MEASUREMENT일 때 필수")
-            @RequestParam(required = false) Integer cropCode,
             @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime measuredAt,
             @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
     ) {
-        return visionInferenceService.inferAndSave(
+        return visionInferenceService.inferDiseaseAndSave(
                 farmId,
                 cropsId,
                 user.id(),
                 image,
                 cameraId,
-                taskType,
+                measuredAt
+        );
+    }
+
+    @Operation(summary = "작물 이미지 생장 추론", description = "이미지를 AI 서버로 전달해 생장 추론 후 DB에 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추론 및 저장 성공"),
+            @ApiResponse(responseCode = "400", description = "cropCode 누락"),
+            @ApiResponse(responseCode = "502", description = "AI 서버 응답 오류"),
+            @ApiResponse(responseCode = "503", description = "AI 서버 연결 실패"),
+            @ApiResponse(responseCode = "504", description = "AI 서버 타임아웃")
+    })
+    @PostMapping("/{farmId}/crops/{cropsId}/growth-inference")
+    public GrowthInferenceCheckResponse inferGrowth(
+            @PathVariable Long farmId,
+            @PathVariable Long cropsId,
+            @RequestParam("image") MultipartFile image,
+            @RequestParam(required = false) Long cameraId,
+            @Parameter(description = "작물 코드(숫자)", required = true)
+            @RequestParam Integer cropCode,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) OffsetDateTime measuredAt,
+            @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
+    ) {
+        return visionInferenceService.inferGrowthAndSave(
+                farmId,
+                cropsId,
+                user.id(),
+                image,
+                cameraId,
                 cropCode,
                 measuredAt
         );

--- a/src/main/java/com/example/practice/dto/crops/AiPredictResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/AiPredictResponse.java
@@ -32,7 +32,11 @@ public record AiPredictResponse(
         @JsonProperty("fruit_count") Integer fruitCount,
         @JsonAlias({"sizeCm", "leaf_area"})
         @JsonProperty("size_cm") BigDecimal sizeCm,
-        String summary
+        String summary,
+        @JsonAlias({"top_confidences"})
+        @JsonProperty("topConfidences") List<BigDecimal> topConfidences,
+        @JsonAlias({"size_px_total"})
+        @JsonProperty("sizePxTotal") BigDecimal sizePxTotal
 ) {
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record TopKItem(String label, BigDecimal p) {

--- a/src/main/java/com/example/practice/dto/crops/GrowthCheckData.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowthCheckData.java
@@ -1,0 +1,29 @@
+package com.example.practice.dto.crops;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.OffsetDateTime;
+
+@Schema(description = "생장 분석 상세 데이터")
+public record GrowthCheckData(
+        @Schema(description = "잎 개수", example = "10")
+        int leafCount,
+        @Schema(description = "잎 전체 픽셀 면적 합(px^2)", example = "23246.75")
+        BigDecimal sizePxTotal,
+        @Schema(description = "잎 개수 산정 신뢰도 임계값", example = "0.6")
+        BigDecimal confidenceThreshold,
+        @Schema(description = "신뢰도(0~100)", example = "53")
+        int confidence,
+        @Schema(description = "업로드 이미지 ID", example = "3")
+        Long uploadedImageId,
+        @Schema(description = "추론 ID", example = "1")
+        Long inferenceId,
+        @Schema(description = "모델명", example = "pe_best.pt")
+        String modelName,
+        @Schema(description = "모델 버전", example = "v1.0.0")
+        String modelVersion,
+        @Schema(description = "추론 시각(UTC)")
+        OffsetDateTime inferredAt
+) {
+}

--- a/src/main/java/com/example/practice/dto/crops/GrowthInferenceCheckResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowthInferenceCheckResponse.java
@@ -1,0 +1,17 @@
+package com.example.practice.dto.crops;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "생장 분석 응답")
+public record GrowthInferenceCheckResponse(
+        @Schema(description = "요청 성공 여부", example = "true")
+        boolean success,
+        @Schema(description = "응답 코드", example = "200")
+        String code,
+        @Schema(description = "생장 분석 데이터")
+        GrowthCheckData data
+) {
+    public static GrowthInferenceCheckResponse ok(GrowthCheckData data) {
+        return new GrowthInferenceCheckResponse(true, "200", data);
+    }
+}

--- a/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
+++ b/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
@@ -3,6 +3,8 @@ package com.example.practice.service.crops;
 import com.example.practice.common.error.AppException;
 import com.example.practice.dto.crops.AiPredictResponse;
 import com.example.practice.dto.crops.DiseaseCheckData;
+import com.example.practice.dto.crops.GrowthCheckData;
+import com.example.practice.dto.crops.GrowthInferenceCheckResponse;
 import com.example.practice.dto.crops.VisionInferenceCheckResponse;
 import com.example.practice.entity.crops.Crops;
 import com.example.practice.entity.crops.DiseaseGuide;
@@ -54,6 +56,7 @@ import java.util.stream.Collectors;
 public class VisionInferenceService {
     private static final String TASK_DISEASE_CLASSIFICATION = "DISEASE_CLASSIFICATION";
     private static final String TASK_GROWTH_MEASUREMENT = "GROWTH_MEASUREMENT";
+    private static final BigDecimal GROWTH_CONFIDENCE_THRESHOLD = BigDecimal.valueOf(0.6);
 
     private final FarmMemberRepository farmMemberRepository;
     private final CropsRepository cropsRepository;
@@ -84,7 +87,54 @@ public class VisionInferenceService {
     );
 
     @Transactional
-    public VisionInferenceCheckResponse inferAndSave(
+    public VisionInferenceCheckResponse inferDiseaseAndSave(
+            Long farmId,
+            Long cropsId,
+            Long userId,
+            MultipartFile image,
+            Long cameraId,
+            OffsetDateTime measuredAt
+    ) {
+        InferenceContext context = inferAndSave(
+                farmId,
+                cropsId,
+                userId,
+                image,
+                cameraId,
+                TASK_DISEASE_CLASSIFICATION,
+                null,
+                measuredAt
+        );
+        DiseaseCheckData data = toCheckData(context.uploadedImage(), context.inference(), context.aiResponse());
+        return VisionInferenceCheckResponse.ok(data);
+    }
+
+    @Transactional
+    public GrowthInferenceCheckResponse inferGrowthAndSave(
+            Long farmId,
+            Long cropsId,
+            Long userId,
+            MultipartFile image,
+            Long cameraId,
+            Integer cropCode,
+            OffsetDateTime measuredAt
+    ) {
+        InferenceContext context = inferAndSave(
+                farmId,
+                cropsId,
+                userId,
+                image,
+                cameraId,
+                TASK_GROWTH_MEASUREMENT,
+                cropCode,
+                measuredAt
+        );
+        GrowthCheckData data = toGrowthCheckData(context.uploadedImage(), context.inference(), context.aiResponse());
+        return GrowthInferenceCheckResponse.ok(data);
+    }
+
+    @Transactional
+    private InferenceContext inferAndSave(
             Long farmId,
             Long cropsId,
             Long userId,
@@ -156,10 +206,7 @@ public class VisionInferenceService {
         measurement.setUpdatedAt(OffsetDateTime.now(ZoneOffset.UTC));
         growthMeasurementRepository.save(measurement);
 
-        DiseaseCheckData data = toCheckData(uploadedImage, inference, aiResponse);
-        return VisionInferenceCheckResponse.ok(
-                data
-        );
+        return new InferenceContext(uploadedImage, inference, aiResponse);
     }
 
     private DiseaseCheckData toCheckData(ImageCapture uploadedImage, VisionInference inference, AiPredictResponse aiResponse) {
@@ -207,6 +254,27 @@ public class VisionInferenceService {
                 causes,
                 symptoms,
                 solutions,
+                uploadedImage.getCaptureId(),
+                inference.getInferenceId(),
+                aiResponse.modelName(),
+                aiResponse.modelVersion(),
+                aiResponse.inferredAt()
+        );
+    }
+
+    private GrowthCheckData toGrowthCheckData(ImageCapture uploadedImage, VisionInference inference, AiPredictResponse aiResponse) {
+        int leafCount = leafCountByThreshold(aiResponse.topConfidences(), GROWTH_CONFIDENCE_THRESHOLD);
+        if (leafCount < 0) {
+            leafCount = aiResponse.leafCount() == null ? 0 : Math.max(aiResponse.leafCount(), 0);
+        }
+        BigDecimal sizePxTotal = firstNonNull(aiResponse.sizePxTotal(), aiResponse.sizeCm(), BigDecimal.ZERO);
+        int confidencePercent = toPercent(aiResponse.confidence());
+
+        return new GrowthCheckData(
+                leafCount,
+                sizePxTotal,
+                GROWTH_CONFIDENCE_THRESHOLD,
+                confidencePercent,
                 uploadedImage.getCaptureId(),
                 inference.getInferenceId(),
                 aiResponse.modelName(),
@@ -317,6 +385,15 @@ public class VisionInferenceService {
         Integer fruitCount = firstNonNull(parsed.fruitCount(), intValue(raw, "fruit_count"), intValue(raw, "fruitCount"));
         BigDecimal sizeCm = firstNonNull(parsed.sizeCm(), decimalValue(raw, "size_cm"), decimalValue(raw, "sizeCm"));
         String summary = firstNonBlank(parsed.summary(), textValue(raw, "summary"));
+        List<BigDecimal> topConfidences = parsed.topConfidences();
+        if (topConfidences == null || topConfidences.isEmpty()) {
+            topConfidences = decimalListValue(raw, "topConfidences", "top_confidences");
+        }
+        BigDecimal sizePxTotal = firstNonNull(
+                parsed.sizePxTotal(),
+                decimalValue(raw, "sizePxTotal"),
+                decimalValue(raw, "size_px_total")
+        );
 
         return new AiPredictResponse(
                 disease,
@@ -334,7 +411,9 @@ public class VisionInferenceService {
                 leafCount,
                 fruitCount,
                 sizeCm,
-                summary
+                summary,
+                topConfidences,
+                sizePxTotal
         );
     }
 
@@ -496,6 +575,49 @@ public class VisionInferenceService {
         return null;
     }
 
+    private List<BigDecimal> decimalListValue(JsonNode raw, String primaryKey, String fallbackKey) {
+        JsonNode node = raw.get(primaryKey);
+        if (node == null || node.isNull()) {
+            node = raw.get(fallbackKey);
+        }
+        if (node == null || node.isNull() || !node.isArray()) {
+            return null;
+        }
+
+        List<BigDecimal> values = new ArrayList<>();
+        for (JsonNode item : node) {
+            if (item == null || item.isNull()) {
+                continue;
+            }
+            if (item.isNumber()) {
+                values.add(item.decimalValue());
+                continue;
+            }
+            if (item.isTextual()) {
+                try {
+                    values.add(new BigDecimal(item.asText().trim()));
+                } catch (NumberFormatException ignored) {
+                    // Skip invalid item.
+                }
+            }
+        }
+        return values;
+    }
+
+    private int leafCountByThreshold(List<BigDecimal> topConfidences, BigDecimal threshold) {
+        if (topConfidences == null || topConfidences.isEmpty()) {
+            return -1;
+        }
+
+        int count = 0;
+        for (BigDecimal confidence : topConfidences) {
+            if (confidence != null && confidence.compareTo(threshold) >= 0) {
+                count++;
+            }
+        }
+        return count;
+    }
+
     @SafeVarargs
     private static <T> T firstNonNull(T... values) {
         if (values == null) {
@@ -532,6 +654,13 @@ public class VisionInferenceService {
         if (TASK_GROWTH_MEASUREMENT.equals(taskType) && cropCode == null) {
             throw new AppException(HttpStatus.BAD_REQUEST, "cropCode is required for GROWTH_MEASUREMENT");
         }
+    }
+
+    private record InferenceContext(
+            ImageCapture uploadedImage,
+            VisionInference inference,
+            AiPredictResponse aiResponse
+    ) {
     }
 
     private String saveCaptureImage(byte[] imageBytes, String originalFilename) {


### PR DESCRIPTION
# 작업 내용
- AI 컨테이너에 성장 모델 디렉터리 볼륨 마운트 추가
- vision-inference에 cropCode 파라미터 추가
- 성장 태스크 요청 시 입력값 검증 로직 보강
- 생장 추론 API를 별도 엔드포인트로 분리
- AI 서버 연동 및 배포 설정 반영
- taskType 허용값 및 cropCode 관련 문서 업데이트

# 변경 이유
- 기존 vision inference 흐름에서 생장 추론 기능을 함께 처리하던 구조를 분리해,
역할을 더 명확하게 나누고 요청/응답 처리의 안정성을 높이기 위해 반영했습니다.
- 또한 작물별 성장 모델을 보다 명확하게 지정할 수 있도록 cropCode를 추가했고,
잘못된 입력 요청을 사전에 차단할 수 있도록 검증 로직도 함께 보완했습니다.
- 배포 환경에서는 성장 모델을 참조할 수 있도록 AI 컨테이너에 모델 디렉터리 마운트 설정을 추가했습니다.

# 기대 효과
- 생장 추론 기능의 책임 분리로 API 구조 명확화
- 작물별 모델 선택 정확도 향상
- 잘못된 요청값 사전 차단으로 안정성 개선
- 운영/배포 환경에서 성장 모델 참조 가능하도록 보완
- 문서와 실제 동작 스펙 일치