### PR TITLE
[FEAT] 성장 지표 시계열 3/7/31일 단위 집계 지원

### DIFF
--- a/src/main/java/com/example/practice/common/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/practice/common/error/GlobalExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.example.practice.common.error;
 
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -13,5 +14,11 @@ public class GlobalExceptionHandler {
     public ResponseEntity<?> handle(AppException e) {
         return ResponseEntity.status(e.getStatus())
                 .body(Map.of("message", e.getMessage()));
+    }
+
+    @ExceptionHandler(HttpMessageNotReadableException.class)
+    public ResponseEntity<?> handle(HttpMessageNotReadableException e) {
+        return ResponseEntity.badRequest()
+                .body(Map.of("message", "invalid request body"));
     }
 }

--- a/src/main/java/com/example/practice/controller/crops/FarmCropGddController.java
+++ b/src/main/java/com/example/practice/controller/crops/FarmCropGddController.java
@@ -55,7 +55,7 @@ public class FarmCropGddController {
         return gddSummaryService.getWindowedTimeSeries(farmId, cropsId, user.id(), windowDays);
     }
 
-    @Operation(summary = "성장 지표 시계열", description = "기간(from~to)의 특정 성장 지표(metric) 시계열을 반환합니다.")
+    @Operation(summary = "성장 지표 시계열", description = "기간(from~to)의 특정 성장 지표(metric) 시계열을 반환합니다. windowDays를 주면 3/7/31일 단위 대표값으로 묶어 반환합니다.")
     @GetMapping("/{farmId}/crops/{cropsId}/growth-metrics")
     public List<GrowthMetricResponse> getGrowthMetrics(
             @PathVariable Long farmId,
@@ -63,9 +63,10 @@ public class FarmCropGddController {
             @RequestParam GrowthMetricType metric,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
+            @RequestParam(required = false) Integer windowDays,
             @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
     ) {
-        return gddSummaryService.getGrowthMetrics(farmId, cropsId, user.id(), metric, from, to);
+        return gddSummaryService.getGrowthMetrics(farmId, cropsId, user.id(), metric, from, to, windowDays);
     }
 
     @Operation(summary = "성장일기 월별 목록", description = "특정 월의 날짜별 카드 리스트를 반환합니다.")

--- a/src/main/java/com/example/practice/controller/crops/FarmCropGddController.java
+++ b/src/main/java/com/example/practice/controller/crops/FarmCropGddController.java
@@ -55,18 +55,16 @@ public class FarmCropGddController {
         return gddSummaryService.getWindowedTimeSeries(farmId, cropsId, user.id(), windowDays);
     }
 
-    @Operation(summary = "성장 지표 시계열", description = "기간(from~to)의 특정 성장 지표(metric) 시계열을 반환합니다. windowDays를 주면 3/7/31일 단위 대표값으로 묶어 반환합니다.")
+    @Operation(summary = "성장 지표 시계열", description = "파종일부터 오늘까지의 특정 성장 지표(metric) 시계열을 반환합니다. windowDays를 주면 3/7/31일 단위 대표값으로 묶어 반환합니다.")
     @GetMapping("/{farmId}/crops/{cropsId}/growth-metrics")
     public List<GrowthMetricResponse> getGrowthMetrics(
             @PathVariable Long farmId,
             @PathVariable Long cropsId,
             @RequestParam GrowthMetricType metric,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate from,
-            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate to,
             @RequestParam(required = false) Integer windowDays,
             @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
     ) {
-        return gddSummaryService.getGrowthMetrics(farmId, cropsId, user.id(), metric, from, to, windowDays);
+        return gddSummaryService.getGrowthMetrics(farmId, cropsId, user.id(), metric, windowDays);
     }
 
     @Operation(summary = "성장일기 월별 목록", description = "특정 월의 날짜별 카드 리스트를 반환합니다.")

--- a/src/main/java/com/example/practice/controller/user/AuthController.java
+++ b/src/main/java/com/example/practice/controller/user/AuthController.java
@@ -14,15 +14,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.nio.file.StandardCopyOption;
 import java.util.List;
-import java.util.UUID;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
@@ -83,38 +75,18 @@ public class AuthController { //whduddnqkqh
 
     @Operation(summary = "프로필 변경", description = "프로필 사진을 변경합니다.")
     @PostMapping("/profile/image")
-    public ResponseEntity<?> uploadProfileImage(
+    public ResponseEntity<String> uploadProfileImage(
             Authentication authentication,
-            @RequestParam("image") MultipartFile imageFile) {
+            @RequestBody ProfileImageUpdateRequest req) {
 
-        // 1. 현재 로그인한 사용자 ID 가져오기
-        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
-        Long userId = principal.id();
-
-        try {
-            // 2. 고유 파일명 생성 (UUID + 원본 확장자)
-            String originalFilename = imageFile.getOriginalFilename();
-            String fileExtension = originalFilename.substring(originalFilename.lastIndexOf("."));
-            String fileName = UUID.randomUUID().toString() + fileExtension;
-
-            // 3. uploads/profile 폴더에 저장
-            Path uploadDir = Paths.get("uploads/profile");
-            Files.createDirectories(uploadDir);  // 폴더 없으면 생성
-
-            Path filePath = uploadDir.resolve(fileName);
-            Files.copy(imageFile.getInputStream(), filePath, StandardCopyOption.REPLACE_EXISTING);
-
-            // 4. DB에 URL 업데이트 (AuthService에 updateProfileImage 메서드 추가 필요)
-            String imageUrl = "/uploads/profile/" + fileName;
-            authService.updateProfileImage(userId, imageUrl);
-
-            // 5. 성공 응답
-            return ResponseEntity.ok().body(imageUrl);
-
-        } catch (IOException e) {
-            return ResponseEntity.internalServerError()
-                    .body("이미지 업로드 실패: " + e.getMessage());
+        if (authentication == null || authentication.getPrincipal() == null) {
+            throw new AppException(HttpStatus.UNAUTHORIZED, "unauthorized");
         }
+
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        String imageUrl = authService.updateProfileImage(principal.id(), req.getImage());
+
+        return ResponseEntity.ok(imageUrl);
     }
 
     @Operation(summary = "사용자 검색", description = "닉네임 검색")

--- a/src/main/java/com/example/practice/dto/user/ProfileImageUpdateRequest.java
+++ b/src/main/java/com/example/practice/dto/user/ProfileImageUpdateRequest.java
@@ -1,0 +1,14 @@
+package com.example.practice.dto.user;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@Schema(description = "프로필 이미지 변경 요청 DTO")
+public class ProfileImageUpdateRequest {
+
+    @Schema(description = "프로필 이미지 ID", example = "4")
+    private String image;
+}

--- a/src/main/java/com/example/practice/service/crops/GddSummaryService.java
+++ b/src/main/java/com/example/practice/service/crops/GddSummaryService.java
@@ -183,20 +183,22 @@ public class GddSummaryService {
             Long userId,
             GrowthMetricType metric,
             LocalDate from,
-            LocalDate to
+            LocalDate to,
+            Integer windowDays
     ) {
         getAccessibleCrop(farmId, cropsId, userId);
 
         if (from.isAfter(to)) {
             throw new AppException(HttpStatus.BAD_REQUEST, "from must be less than or equal to to");
         }
+        validateWindowDays(windowDays);
 
         OffsetDateTime fromAt = from.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
         OffsetDateTime toExclusive = to.plusDays(1).atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
         List<GrowthMeasurement> rows = growthMeasurementRepository
                 .findAllByCrops_CropsIdAndMeasuredAtBetweenOrderByMeasuredAtAsc(cropsId, fromAt, toExclusive.minusNanos(1));
 
-        return rows.stream()
+        List<GrowthMetricResponse> metrics = rows.stream()
                 .map(row -> new GrowthMetricResponse(
                         row.getMeasuredAt().toLocalDate(),
                         resolveMetricValue(metric, row),
@@ -205,6 +207,54 @@ public class GddSummaryService {
                 ))
                 .filter(row -> row.value() != null)
                 .toList();
+
+        if (windowDays == null || windowDays == 1) {
+            return metrics;
+        }
+
+        return bucketGrowthMetrics(metrics, from, to, windowDays);
+    }
+
+    private void validateWindowDays(Integer windowDays) {
+        if (windowDays == null || windowDays == 1) {
+            return;
+        }
+        if (windowDays != 3 && windowDays != 7 && windowDays != 31) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "windowDays must be one of 3, 7, 31");
+        }
+    }
+
+    private List<GrowthMetricResponse> bucketGrowthMetrics(
+            List<GrowthMetricResponse> metrics,
+            LocalDate from,
+            LocalDate to,
+            int windowDays
+    ) {
+        Map<LocalDate, GrowthMetricResponse> latestByBucketStart = new LinkedHashMap<>();
+
+        for (GrowthMetricResponse metric : metrics) {
+            long daysFromStart = ChronoUnit.DAYS.between(from, metric.date());
+            long bucketIndex = daysFromStart / windowDays;
+            LocalDate bucketStart = from.plusDays(bucketIndex * windowDays);
+            latestByBucketStart.put(bucketStart, metric);
+        }
+
+        List<GrowthMetricResponse> result = new ArrayList<>();
+        LocalDate cursor = from;
+        while (!cursor.isAfter(to)) {
+            GrowthMetricResponse bucketMetric = latestByBucketStart.get(cursor);
+            if (bucketMetric != null) {
+                result.add(new GrowthMetricResponse(
+                        bucketMetric.date(),
+                        bucketMetric.value(),
+                        bucketMetric.source(),
+                        bucketMetric.imageId()
+                ));
+            }
+            cursor = cursor.plusDays(windowDays);
+        }
+
+        return result;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/practice/service/crops/GddSummaryService.java
+++ b/src/main/java/com/example/practice/service/crops/GddSummaryService.java
@@ -182,16 +182,16 @@ public class GddSummaryService {
             Long cropsId,
             Long userId,
             GrowthMetricType metric,
-            LocalDate from,
-            LocalDate to,
             Integer windowDays
     ) {
-        getAccessibleCrop(farmId, cropsId, userId);
-
-        if (from.isAfter(to)) {
-            throw new AppException(HttpStatus.BAD_REQUEST, "from must be less than or equal to to");
+        Crops crop = getAccessibleCrop(farmId, cropsId, userId);
+        if (crop.getPlantingDate() == null) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "plantingDate is required");
         }
         validateWindowDays(windowDays);
+
+        LocalDate from = crop.getPlantingDate();
+        LocalDate to = LocalDate.now();
 
         OffsetDateTime fromAt = from.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
         OffsetDateTime toExclusive = to.plusDays(1).atStartOfDay().atOffset(OffsetDateTime.now().getOffset());

--- a/src/main/java/com/example/practice/service/user/AuthService.java
+++ b/src/main/java/com/example/practice/service/user/AuthService.java
@@ -16,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.security.SecureRandom;
 import java.time.OffsetDateTime;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.List;
 
 @Service
@@ -150,12 +151,14 @@ public class AuthService {
     }
 
     @Transactional
-    public void updateProfileImage(Long userId, String imageUrl) {
+    public String updateProfileImage(Long userId, String imageId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "사용자 없음"));
 
+        String imageUrl = buildProfileImageUrl(imageId);
         user.setProfileImageUrl(imageUrl);
         userRepository.save(user);
+        return imageUrl;
     }
 
 
@@ -180,5 +183,12 @@ public class AuthService {
         random.nextBytes(bytes);
         // URL-safe
         return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+    }
+
+    private String buildProfileImageUrl(String imageId) {
+        if (imageId == null || imageId.trim().isEmpty()) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "image is required");
+        }
+        return buildS3ImageUrl(Collections.singletonList(imageId));
     }
 }


### PR DESCRIPTION
## 작업 내용
- 기존 `GET /api/v1/farms/{farmId}/crops/{cropsId}/growth-metrics` API를 확장했습니다.
- 별도 엔드포인트를 추가하지 않고, 기존 성장 지표 조회 API에서 `windowDays` 파라미터를 통해 3일/7일/31일 단위 집계 조회를 지원하도록 변경했습니다.
- `from`, `to`를 받지 않고 `crops.planting_date`부터 오늘까지를 기준으로 조회하도록 수정했습니다.

## 변경 사항
- `metric` 파라미터로 성장 지표 종류를 선택할 수 있습니다.
  - `LEAF_COUNT`
  - `FRUIT_COUNT`
  - `SIZE_CM`
  - `HEIGHT_CM`
- `windowDays=3|7|31` 전달 시 해당 단위로 성장 지표를 묶어서 반환합니다.
- `windowDays`가 없거나 `1`이면 기존처럼 원본 시계열을 그대로 반환합니다.

## 구현 방식
- `growth_measurement` 테이블의 원본 데이터를 조회합니다.
- 작물의 `planting_date`부터 오늘까지를 범위로 사용합니다.
- 요청한 `windowDays` 기준으로 버킷을 생성합니다.
- 각 구간의 마지막 측정값을 대표값으로 반환하도록 구현했습니다.


## 기대 효과
- 프론트 성장 추적 화면에서 `3일 단위 / 7일 단위 / 31일 단위` 탭 요구사항을 기존 API 확장만으로 대응할 수 있습니다.
- GDD 구간 시계열과 유사한 방식으로 성장 지표도 구간 단위 조회가 가능해졌습니다.
