### PR TITLE
[Feat] deviceId 기반 카메라 캡처 기능 추가

### DIFF
--- a/src/main/java/com/example/practice/controller/device/DeviceCameraController.java
+++ b/src/main/java/com/example/practice/controller/device/DeviceCameraController.java
@@ -1,0 +1,35 @@
+package com.example.practice.controller.device;
+
+import com.example.practice.common.config.TokenAuthFilter;
+import com.example.practice.dto.farm.CameraCaptureResponse;
+import com.example.practice.service.farm.FarmCameraService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "Device Camera", description = "디바이스 카메라 API")
+@SecurityRequirement(name = "JWT")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/devices")
+public class DeviceCameraController {
+
+    private final FarmCameraService farmCameraService;
+
+    @Operation(summary = "디바이스 카메라 캡처", description = "device에 연결된 카메라에서 현재 이미지를 캡처해 저장합니다.")
+    @PostMapping("/{deviceId}/camera/capture")
+    public CameraCaptureResponse captureByDevice(
+            @PathVariable Long deviceId,
+            @RequestParam(required = false) Long cameraId,
+            @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
+    ) {
+        return farmCameraService.captureDeviceCamera(deviceId, cameraId, user.id());
+    }
+}

--- a/src/main/java/com/example/practice/repository/device/CameraRepository.java
+++ b/src/main/java/com/example/practice/repository/device/CameraRepository.java
@@ -14,6 +14,12 @@ public interface CameraRepository extends JpaRepository<Camera, Long> {
 
     Optional<Camera> findByCameraIdAndDevice_FarmId(Long cameraId, Long farmId);
 
+    Optional<Camera> findFirstByDevice_DeviceIdAndPrimaryTrueOrderByCameraIdAsc(Long deviceId);
+
+    Optional<Camera> findFirstByDevice_DeviceIdOrderByPrimaryDescCameraIdAsc(Long deviceId);
+
+    Optional<Camera> findByCameraIdAndDevice_DeviceId(Long cameraId, Long deviceId);
+
     List<Camera> findAllByDevice_FarmId(Long farmId);
 
     void deleteAllByDevice_FarmId(Long farmId);

--- a/src/main/java/com/example/practice/service/farm/FarmCameraService.java
+++ b/src/main/java/com/example/practice/service/farm/FarmCameraService.java
@@ -5,10 +5,12 @@ import com.example.practice.dto.farm.CameraCaptureResponse;
 import com.example.practice.dto.farm.CameraStreamResponse;
 import com.example.practice.entity.crops.ImageCapture;
 import com.example.practice.entity.device.Camera;
+import com.example.practice.entity.device.Device;
 import com.example.practice.repository.crops.ImageCaptureRepository;
 import com.example.practice.repository.device.CameraRepository;
 import com.example.practice.repository.farm.FarmMemberRepository;
 import com.example.practice.service.aws.AwsS3Service;
+import com.example.practice.service.device.DeviceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.io.ByteArrayResource;
@@ -37,6 +39,7 @@ public class FarmCameraService {
     private final CameraRepository cameraRepository;
     private final ImageCaptureRepository imageCaptureRepository;
     private final AwsS3Service awsS3Service;
+    private final DeviceService deviceService;
     private final WebClient.Builder webClientBuilder;
 
     @Value("${file.upload-dir}")
@@ -82,16 +85,25 @@ public class FarmCameraService {
             throw new AppException(HttpStatus.FORBIDDEN, "farm access denied");
         }
 
-        return captureCameraInternal(farmId, cameraId);
+        return captureCameraInternal(resolveCamera(farmId, cameraId));
+    }
+
+    @Transactional
+    public CameraCaptureResponse captureDeviceCamera(Long deviceId, Long cameraId, Long userId) {
+        Device device = deviceService.findById(deviceId);
+        if (!farmMemberRepository.existsByFarmIdAndUserId(device.getFarmId(), userId)) {
+            throw new AppException(HttpStatus.FORBIDDEN, "farm access denied");
+        }
+
+        return captureCameraInternal(resolveCameraByDevice(deviceId, cameraId));
     }
 
     @Transactional
     public CameraCaptureResponse captureFarmCameraForSchedule(Long farmId, Long cameraId) {
-        return captureCameraInternal(farmId, cameraId);
+        return captureCameraInternal(resolveCamera(farmId, cameraId));
     }
 
-    private CameraCaptureResponse captureCameraInternal(Long farmId, Long cameraId) {
-        Camera camera = resolveCamera(farmId, cameraId);
+    private CameraCaptureResponse captureCameraInternal(Camera camera) {
         if (camera.getCaptureEndpoint() == null || camera.getCaptureEndpoint().isBlank()) {
             throw new AppException(HttpStatus.NOT_FOUND, "camera capture endpoint not configured");
         }
@@ -125,6 +137,17 @@ public class FarmCameraService {
         return cameraRepository.findFirstByDevice_FarmIdAndPrimaryTrueOrderByCameraIdAsc(farmId)
                 .or(() -> cameraRepository.findFirstByDevice_FarmIdOrderByPrimaryDescCameraIdAsc(farmId))
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for farm"));
+    }
+
+    private Camera resolveCameraByDevice(Long deviceId, Long cameraId) {
+        if (cameraId != null) {
+            return cameraRepository.findByCameraIdAndDevice_DeviceId(cameraId, deviceId)
+                    .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not found in device"));
+        }
+
+        return cameraRepository.findFirstByDevice_DeviceIdAndPrimaryTrueOrderByCameraIdAsc(deviceId)
+                .or(() -> cameraRepository.findFirstByDevice_DeviceIdOrderByPrimaryDescCameraIdAsc(deviceId))
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for device"));
     }
 
     private String buildStreamUrl(String streamKey, String protocol) {


### PR DESCRIPTION
## 변경 사항

- `POST /api/devices/{deviceId}/camera/capture` API 추가
- deviceId 기준으로 연결된 카메라를 조회해 캡처하도록 서비스 로직 추가
- deviceId 기준 카메라 조회용 Repository 메서드 추가
- 기존 `POST /api/v1/farms/{farmId}/camera/capture` API는 그대로 유지

## 동작 방식

- 요청한 `deviceId`로 디바이스를 조회
- 디바이스의 `farmId`를 기준으로 사용자 권한 확인
- 해당 device에 연결된 primary camera를 조회
- `camera.capture_endpoint`로 캡처 요청
- 반환된 이미지를 S3 `captures/` 경로에 업로드
- 업로드된 이미지 URL을 응답으로 반환

## 테스트

- 라즈베리파이 카메라 서버 확인
  - `GET http://100.127.222.7:8000/health` 성공
  - `POST http://100.127.222.7:8000/capture` JPEG 반환 확인
- 운영 DB에 deviceId 4 카메라 endpoint 설정 확인
  - `camera.capture_endpoint = http://100.127.222.7:8000/capture`
