### PR TITLE
[feat] 카메라 스케줄러 및 성장일기·작물 추천 API 확장

### DIFF
--- a/src/main/java/com/example/practice/controller/crops/CropRecommendController.java
+++ b/src/main/java/com/example/practice/controller/crops/CropRecommendController.java
@@ -1,13 +1,18 @@
 package com.example.practice.controller.crops;
 
+import com.example.practice.dto.crops.AiCropRecommendRequest;
+import com.example.practice.dto.crops.AiCropRecommendResponse;
 import com.example.practice.dto.crops.CropRecommendResponse;
 import com.example.practice.service.crops.CropRecommendService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -32,5 +37,13 @@ public class CropRecommendController {
     @Operation(summary = "작물 추천")
     public ResponseEntity<CropRecommendResponse> recommend(@RequestParam Long deviceId) {
         return ResponseEntity.ok(cropRecommendService.recommend(deviceId));
+    }
+
+    @PostMapping("/ai")
+    @Operation(summary = "AI 설문 기반 작물 추천")
+    public ResponseEntity<AiCropRecommendResponse> recommendByAi(
+            @Valid @RequestBody AiCropRecommendRequest request
+    ) {
+        return ResponseEntity.ok(cropRecommendService.recommendByAi(request));
     }
 }

--- a/src/main/java/com/example/practice/controller/device/DeviceCameraController.java
+++ b/src/main/java/com/example/practice/controller/device/DeviceCameraController.java
@@ -1,12 +1,14 @@
 package com.example.practice.controller.device;
 
 import com.example.practice.common.config.TokenAuthFilter;
+import com.example.practice.common.error.AppException;
 import com.example.practice.dto.farm.CameraCaptureResponse;
 import com.example.practice.service.farm.FarmCameraService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -30,6 +32,9 @@ public class DeviceCameraController {
             @RequestParam(required = false) Long cameraId,
             @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
     ) {
+        if (user == null) {
+            throw new AppException(HttpStatus.UNAUTHORIZED, "authentication is required");
+        }
         return farmCameraService.captureDeviceCamera(deviceId, cameraId, user.id());
     }
 }

--- a/src/main/java/com/example/practice/dto/crops/AiCropRecommendRequest.java
+++ b/src/main/java/com/example/practice/dto/crops/AiCropRecommendRequest.java
@@ -1,0 +1,18 @@
+package com.example.practice.dto.crops;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record AiCropRecommendRequest(
+        @NotBlank(message = "location is required")
+        String location,
+        @NotNull(message = "place is required")
+        GrowPlace place,
+        @NotNull(message = "careTime is required")
+        CareTime careTime,
+        @NotNull(message = "purpose is required")
+        GrowPurpose purpose,
+        @NotNull(message = "harvestCycle is required")
+        HarvestCycle harvestCycle
+) {
+}

--- a/src/main/java/com/example/practice/dto/crops/AiCropRecommendResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/AiCropRecommendResponse.java
@@ -1,0 +1,9 @@
+package com.example.practice.dto.crops;
+
+import java.util.List;
+
+public record AiCropRecommendResponse(
+        List<AiCropRecommendation> recommendations,
+        String message
+) {
+}

--- a/src/main/java/com/example/practice/dto/crops/AiCropRecommendation.java
+++ b/src/main/java/com/example/practice/dto/crops/AiCropRecommendation.java
@@ -1,0 +1,11 @@
+package com.example.practice.dto.crops;
+
+public record AiCropRecommendation(
+        int rank,
+        String cropName,
+        String reason,
+        Difficulty difficulty,
+        String harvestCycle,
+        Integer estimatedHarvestDays
+) {
+}

--- a/src/main/java/com/example/practice/dto/crops/CareTime.java
+++ b/src/main/java/com/example/practice/dto/crops/CareTime.java
@@ -1,0 +1,18 @@
+package com.example.practice.dto.crops;
+
+public enum CareTime {
+    UNDER_FIVE_MINUTES("5분 이내 (최소 관리)"),
+    AROUND_FIFTEEN_MINUTES("15분 내외 (적정 관리)"),
+    OVER_THIRTY_MINUTES("30분 이상 (집중 관리)"),
+    ONCE_OR_TWICE_A_WEEK("주 1~2회 (비정기 관리)");
+
+    private final String label;
+
+    CareTime(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/example/practice/dto/crops/Difficulty.java
+++ b/src/main/java/com/example/practice/dto/crops/Difficulty.java
@@ -1,0 +1,7 @@
+package com.example.practice.dto.crops;
+
+public enum Difficulty {
+    EASY,
+    MEDIUM,
+    HARD
+}

--- a/src/main/java/com/example/practice/dto/crops/GrowPlace.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowPlace.java
@@ -1,0 +1,18 @@
+package com.example.practice.dto.crops;
+
+public enum GrowPlace {
+    INDOOR_WINDOW_DESK("실내 창가/책상"),
+    APARTMENT_BALCONY("아파트 베란다"),
+    ROOFTOP_YARD_GARDEN("옥상/마당/텃밭"),
+    SMART_FARM_LIGHTING("조명 시설이 갖춰진 스마트팜");
+
+    private final String label;
+
+    GrowPlace(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/example/practice/dto/crops/GrowPurpose.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowPurpose.java
@@ -1,0 +1,18 @@
+package com.example.practice.dto.crops;
+
+public enum GrowPurpose {
+    PRACTICAL_FOOD("실용적인 식재료"),
+    HEALING_AESTHETIC("심미적 힐링"),
+    EDUCATION_OBSERVATION("아이들 교육/성장 관찰"),
+    COST_EFFECTIVE("최고의 가성비");
+
+    private final String label;
+
+    GrowPurpose(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/example/practice/dto/crops/GrowthDiaryCardResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowthDiaryCardResponse.java
@@ -4,12 +4,9 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record GrowthDiaryCardResponse(
+        int month,
+        int day,
         LocalDate date,
-        String thumbnailUrl,
-        Integer leafDelta,
-        Integer fruitDelta,
-        BigDecimal sizeDeltaCm,
-        String diseaseName,
-        BigDecimal diseaseConfidence
+        BigDecimal gdd
 ) {
 }

--- a/src/main/java/com/example/practice/dto/crops/GrowthDiaryDetailResponse.java
+++ b/src/main/java/com/example/practice/dto/crops/GrowthDiaryDetailResponse.java
@@ -4,6 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 public record GrowthDiaryDetailResponse(
+        String farmName,
         LocalDate date,
         String imageUrl,
         Temperature temperature,
@@ -14,12 +15,12 @@ public record GrowthDiaryDetailResponse(
     public record Temperature(BigDecimal min, BigDecimal max, BigDecimal avg) {
     }
 
-    public record Growth(Integer leafCount, Integer fruitCount, BigDecimal sizeCm) {
+    public record Growth(BigDecimal sizeCm, Integer leafCount, Integer fruitCount) {
     }
 
     public record Gdd(BigDecimal daily, BigDecimal cumulative) {
     }
 
-    public record Disease(String name, BigDecimal confidence) {
+    public record Disease(String status, String name, BigDecimal confidence) {
     }
 }

--- a/src/main/java/com/example/practice/dto/crops/HarvestCycle.java
+++ b/src/main/java/com/example/practice/dto/crops/HarvestCycle.java
@@ -1,0 +1,18 @@
+package com.example.practice.dto.crops;
+
+public enum HarvestCycle {
+    SHORT_TERM("단기 재배 (4주 이내)"),
+    MID_TERM("중기 재배 (4주 ~ 12주)"),
+    LONG_TERM("장기 재배 (12주 이상)"),
+    CONTINUOUS("지속 수확 (상시 수확)");
+
+    private final String label;
+
+    HarvestCycle(String label) {
+        this.label = label;
+    }
+
+    public String getLabel() {
+        return label;
+    }
+}

--- a/src/main/java/com/example/practice/repository/crops/VisionInferenceRepository.java
+++ b/src/main/java/com/example/practice/repository/crops/VisionInferenceRepository.java
@@ -2,10 +2,34 @@ package com.example.practice.repository.crops;
 
 import com.example.practice.entity.crops.VisionInference;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+import java.time.OffsetDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface VisionInferenceRepository extends JpaRepository<VisionInference, Long> {
+
+    @Query(value = """
+        select vi.*
+        from vision_inference vi
+        join image_capture ic on vi.capture_id = ic.capture_id
+        join camera c on ic.camera_id = c.camera_id
+        join device d on c.device_id = d.device_id
+        where d.farm_id = :farmId
+          and vi.task_type = :taskType
+          and ic.captured_at between :from and :to
+          and vi.deleted_at is null
+        order by coalesce(vi.inferred_at, vi.created_at, ic.captured_at) desc
+        limit 1
+        """, nativeQuery = true)
+    Optional<VisionInference> findLatestByFarmIdAndTaskTypeAndCapturedAtBetween(
+            @Param("farmId") Long farmId,
+            @Param("taskType") String taskType,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to
+    );
 
     void deleteAllByCapture_CameraIdIn(List<Long> cameraIds);
 }

--- a/src/main/java/com/example/practice/repository/device/SensorReadingRepository.java
+++ b/src/main/java/com/example/practice/repository/device/SensorReadingRepository.java
@@ -51,6 +51,24 @@ public interface SensorReadingRepository extends JpaRepository<SensorReading, Lo
             @Param("from") OffsetDateTime from,
             @Param("to") OffsetDateTime to
     );
+
+    @Query("""
+            SELECT sr.value
+            FROM SensorReading sr
+            JOIN sr.sensor s
+            JOIN s.device d
+            WHERE d.farmId = :farmId
+              AND s.sensorType = :sensorType
+              AND sr.measuredAt BETWEEN :from AND :to
+              AND sr.value IS NOT NULL
+            """)
+    List<BigDecimal> findDailyValuesByFarmIdAndSensorType(
+            @Param("farmId") Long farmId,
+            @Param("sensorType") SensorType sensorType,
+            @Param("from") OffsetDateTime from,
+            @Param("to") OffsetDateTime to
+    );
+
     @Query(value = """
         select sr.value
         from sensor_reading sr

--- a/src/main/java/com/example/practice/service/crops/CropRecommendService.java
+++ b/src/main/java/com/example/practice/service/crops/CropRecommendService.java
@@ -1,16 +1,23 @@
 package com.example.practice.service.crops;
 
+import com.example.practice.common.config.OpenAiProperties;
 import com.example.practice.dto.Device.SensorCheckDetail;
 import com.example.practice.dto.Device.SensorValueSnapshot;
+import com.example.practice.dto.crops.AiCropRecommendRequest;
+import com.example.practice.dto.crops.AiCropRecommendResponse;
+import com.example.practice.dto.crops.AiCropRecommendation;
 import com.example.practice.dto.crops.CropRecommendResponse;
 import com.example.practice.dto.crops.CropRecommendation;
+import com.example.practice.dto.crops.Difficulty;
 import com.example.practice.entity.device.EnvData;
 import com.example.practice.entity.device.SensorType;
 import com.example.practice.entity.environment.CropEnvironmentStandard;
 import com.example.practice.repository.crops.CropEnvironmentStandardRepository;
 import com.example.practice.repository.device.EnvDataRepository;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
 
 import java.math.BigDecimal;
 import java.util.*;
@@ -23,6 +30,9 @@ public class CropRecommendService {
 
     private final EnvDataRepository envDataRepository;
     private final CropEnvironmentStandardRepository cropEnvironmentStandardRepository;
+    private final WebClient openAiWebClient;
+    private final OpenAiProperties openAiProperties;
+    private final ObjectMapper objectMapper;
 
     public CropRecommendResponse recommend(Long deviceId) {
 
@@ -67,6 +77,170 @@ public class CropRecommendService {
                 .recommendations(recommendations)
                 .message(message)
                 .build();
+    }
+
+    public AiCropRecommendResponse recommendByAi(AiCropRecommendRequest request) {
+        try {
+            AiCropRecommendResponse response = requestAiRecommendations(request);
+            if (response.recommendations() == null || response.recommendations().isEmpty()) {
+                return fallbackRecommendations(request);
+            }
+            return response;
+        } catch (Exception e) {
+            return fallbackRecommendations(request);
+        }
+    }
+
+    private AiCropRecommendResponse requestAiRecommendations(AiCropRecommendRequest request) throws Exception {
+        String model = openAiProperties.getModel();
+        if (model == null || model.isBlank()) {
+            model = "gpt-5-mini";
+        }
+
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", model);
+        requestBody.put("input", buildAiInput(request));
+        requestBody.put("instructions", buildAiInstructions());
+        requestBody.put("max_output_tokens", 900);
+
+        Map<String, Object> reasoning = new HashMap<>();
+        reasoning.put("effort", "low");
+        requestBody.put("reasoning", reasoning);
+
+        Map<String, Object> response = openAiWebClient.post()
+                .uri("/v1/responses")
+                .bodyValue(requestBody)
+                .retrieve()
+                .bodyToMono(Map.class)
+                .block();
+
+        String outputText = stripJsonFence(extractOutputText(response));
+        if (outputText == null || outputText.isBlank()) {
+            throw new IllegalStateException("empty OpenAI recommendation response");
+        }
+        return objectMapper.readValue(outputText, AiCropRecommendResponse.class);
+    }
+
+    private String buildAiInput(AiCropRecommendRequest request) {
+        return """
+                location: %s
+                place: %s
+                careTime: %s
+                purpose: %s
+                harvestCycle: %s
+                """.formatted(
+                request.location(),
+                request.place().getLabel(),
+                request.careTime().getLabel(),
+                request.purpose().getLabel(),
+                request.harvestCycle().getLabel()
+        );
+    }
+
+    private String buildAiInstructions() {
+        return """
+                너는 한국 가정/소규모 스마트팜 작물 추천 전문가다.
+                사용자의 위치, 재배 장소, 관리 가능 시간, 재배 목적, 선호 수확 주기를 바탕으로 작물 3개를 추천해라.
+                현재 한국의 계절과 지역 기후를 고려하되, 확실하지 않은 날씨 수치는 단정하지 마라.
+                추천 작물은 사용자가 실제로 키우기 쉬운 채소, 허브, 과채류 중심으로 고른다.
+                반드시 JSON만 반환하고, 마크다운 코드블록이나 설명 문장은 넣지 마라.
+                JSON 형식:
+                {
+                  "recommendations": [
+                    {
+                      "rank": 1,
+                      "cropName": "상추",
+                      "reason": "관리 시간이 짧아도 잘 자라고 빠른 수확이 가능해요.",
+                      "difficulty": "EASY",
+                      "harvestCycle": "지속 수확",
+                      "estimatedHarvestDays": 30
+                    }
+                  ],
+                  "message": "현재 환경에 잘 맞는 작물을 찾았어요!"
+                }
+                difficulty는 EASY, MEDIUM, HARD 중 하나만 사용해라.
+                reason은 한국어 한 문장으로 35자 이내로 작성해라.
+                recommendations는 정확히 3개만 반환해라.
+                """;
+    }
+
+    private AiCropRecommendResponse fallbackRecommendations(AiCropRecommendRequest request) {
+        List<AiCropRecommendation> recommendations = switch (request.purpose()) {
+            case HEALING_AESTHETIC -> List.of(
+                    new AiCropRecommendation(1, "바질", "향이 좋아 실내 힐링용으로 잘 맞아요.", Difficulty.EASY, "지속 수확", 35),
+                    new AiCropRecommendation(2, "로즈마리", "관상과 향을 함께 즐기기 좋아요.", Difficulty.MEDIUM, "장기 재배", 90),
+                    new AiCropRecommendation(3, "민트", "생장이 빠르고 활용도가 높아요.", Difficulty.EASY, "지속 수확", 30)
+            );
+            case EDUCATION_OBSERVATION -> List.of(
+                    new AiCropRecommendation(1, "방울토마토", "꽃과 열매 변화를 관찰하기 좋아요.", Difficulty.MEDIUM, "중기 재배", 70),
+                    new AiCropRecommendation(2, "상추", "성장 속도가 빨라 관찰이 쉬워요.", Difficulty.EASY, "지속 수확", 30),
+                    new AiCropRecommendation(3, "강낭콩", "싹과 줄기 성장이 뚜렷해요.", Difficulty.EASY, "중기 재배", 60)
+            );
+            case COST_EFFECTIVE -> List.of(
+                    new AiCropRecommendation(1, "대파", "다시 자라 활용도가 높아요.", Difficulty.EASY, "지속 수확", 30),
+                    new AiCropRecommendation(2, "상추", "구매 빈도가 높아 직접 키우기 좋아요.", Difficulty.EASY, "지속 수확", 30),
+                    new AiCropRecommendation(3, "바질", "소량 구매가 비싸 직접 재배가 유리해요.", Difficulty.EASY, "지속 수확", 35)
+            );
+            default -> List.of(
+                    new AiCropRecommendation(1, "상추", "관리가 쉽고 빠른 수확이 가능해요.", Difficulty.EASY, "지속 수확", 30),
+                    new AiCropRecommendation(2, "방울토마토", "수확 재미가 있고 활용도가 높아요.", Difficulty.MEDIUM, "중기 재배", 70),
+                    new AiCropRecommendation(3, "바질", "향기롭고 요리에 바로 쓰기 좋아요.", Difficulty.EASY, "지속 수확", 35)
+            );
+        };
+
+        return new AiCropRecommendResponse(recommendations, "현재 환경에 잘 맞는 작물을 찾았어요!");
+    }
+
+    private String extractOutputText(Map<String, Object> response) {
+        if (response == null) {
+            return null;
+        }
+
+        Object output = response.get("output");
+        if (!(output instanceof List<?> outputList)) {
+            return null;
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (Object outputItem : outputList) {
+            if (!(outputItem instanceof Map<?, ?> outputMap)) {
+                continue;
+            }
+            Object content = outputMap.get("content");
+            if (!(content instanceof List<?> contentList)) {
+                continue;
+            }
+            for (Object contentItem : contentList) {
+                if (!(contentItem instanceof Map<?, ?> contentMap)) {
+                    continue;
+                }
+                Object type = contentMap.get("type");
+                Object text = contentMap.get("text");
+                if ("output_text".equals(type) && text instanceof String textValue) {
+                    if (!sb.isEmpty()) {
+                        sb.append("\n");
+                    }
+                    sb.append(textValue);
+                }
+            }
+        }
+        return sb.isEmpty() ? null : sb.toString();
+    }
+
+    private String stripJsonFence(String text) {
+        if (text == null) {
+            return null;
+        }
+        String trimmed = text.trim();
+        if (trimmed.startsWith("```json")) {
+            trimmed = trimmed.substring(7).trim();
+        } else if (trimmed.startsWith("```")) {
+            trimmed = trimmed.substring(3).trim();
+        }
+        if (trimmed.endsWith("```")) {
+            trimmed = trimmed.substring(0, trimmed.length() - 3).trim();
+        }
+        return trimmed;
     }
 
     // ──────────────────────────────────────────────────────────────────

--- a/src/main/java/com/example/practice/service/crops/GddSummaryService.java
+++ b/src/main/java/com/example/practice/service/crops/GddSummaryService.java
@@ -289,34 +289,18 @@ public class GddSummaryService {
         }
         LocalDate monthEnd = monthStart.withDayOfMonth(monthStart.lengthOfMonth());
 
-        OffsetDateTime fromAt = monthStart.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
-        OffsetDateTime toAt = monthEnd.plusDays(1).atStartOfDay().atOffset(OffsetDateTime.now().getOffset()).minusNanos(1);
+        List<CropGddDaily> rows = cropGddDailyRepository
+                .findAllByCrops_CropsIdAndTargetDateBetweenOrderByTargetDateAsc(cropsId, monthStart, monthEnd);
 
-        List<GrowthMeasurement> monthRows = growthMeasurementRepository
-                .findAllByCrops_CropsIdAndMeasuredAtBetweenOrderByMeasuredAtAsc(cropsId, fromAt, toAt);
-
-        GrowthMeasurement previous = growthMeasurementRepository
-                .findTopByCrops_CropsIdAndMeasuredAtLessThanOrderByMeasuredAtDesc(cropsId, fromAt)
-                .orElse(null);
-
-        // 날짜별 카드 1개만 필요하므로 같은 날짜는 가장 마지막 측정값을 사용한다.
-        Map<LocalDate, GrowthMeasurement> latestByDate = new LinkedHashMap<>();
-        for (GrowthMeasurement row : monthRows) {
-            latestByDate.put(row.getMeasuredAt().toLocalDate(), row);
-        }
-
-        List<GrowthDiaryCardResponse> response = new ArrayList<>(latestByDate.size());
-        for (GrowthMeasurement current : latestByDate.values()) {
+        List<GrowthDiaryCardResponse> response = new ArrayList<>(rows.size());
+        for (CropGddDaily row : rows) {
+            LocalDate targetDate = row.getTargetDate();
             response.add(new GrowthDiaryCardResponse(
-                    current.getMeasuredAt().toLocalDate(),
-                    null,
-                    diffInt(current.getLeafCount(), previous == null ? null : previous.getLeafCount()),
-                    diffInt(current.getFruitCount(), previous == null ? null : previous.getFruitCount()),
-                    diffDecimal(resolveSizeCm(current), previous == null ? null : resolveSizeCm(previous)),
-                    null,
-                    null
+                    targetDate.getMonthValue(),
+                    targetDate.getDayOfMonth(),
+                    targetDate,
+                    row.getGdd()
             ));
-            previous = current;
         }
 
         return response;

--- a/src/main/java/com/example/practice/service/crops/GddSummaryService.java
+++ b/src/main/java/com/example/practice/service/crops/GddSummaryService.java
@@ -13,9 +13,13 @@ import com.example.practice.entity.crops.Crops;
 import com.example.practice.entity.crops.GrowthMeasurement;
 import com.example.practice.entity.crops.GrowthMetricSource;
 import com.example.practice.entity.crops.GrowthMetricType;
+import com.example.practice.entity.crops.VisionInference;
+import com.example.practice.entity.device.SensorType;
 import com.example.practice.repository.crops.CropGddDailyRepository;
 import com.example.practice.repository.crops.CropsRepository;
 import com.example.practice.repository.crops.GrowthMeasurementRepository;
+import com.example.practice.repository.crops.VisionInferenceRepository;
+import com.example.practice.repository.device.SensorReadingRepository;
 import com.example.practice.repository.farm.FarmMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -27,6 +31,7 @@ import java.math.RoundingMode;
 import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.OffsetDateTime;
+import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -41,10 +46,15 @@ import com.example.practice.dto.crops.GrowthDiaryCardResponse;
 public class GddSummaryService {
 
     private static final BigDecimal MIN_AVG_DAILY_GDD = BigDecimal.valueOf(0.01);
+    private static final String TASK_DISEASE_CLASSIFICATION = "DISEASE_CLASSIFICATION";
+    private static final String TASK_GROWTH_MEASUREMENT = "GROWTH_MEASUREMENT";
+    private static final ZoneId DIARY_ZONE = ZoneId.of("Asia/Seoul");
 
     private final CropsRepository cropsRepository;
     private final CropGddDailyRepository cropGddDailyRepository;
     private final GrowthMeasurementRepository growthMeasurementRepository;
+    private final VisionInferenceRepository visionInferenceRepository;
+    private final SensorReadingRepository sensorReadingRepository;
     private final FarmMemberRepository farmMemberRepository;
     private final SensorGddIngestionService sensorGddIngestionService;
 
@@ -321,23 +331,44 @@ public class GddSummaryService {
     ) {
         Crops crop = getAccessibleCrop(farmId, cropsId, userId);
 
-        OffsetDateTime dayStart = date.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
-        OffsetDateTime dayEnd = date.plusDays(1).atStartOfDay().atOffset(OffsetDateTime.now().getOffset()).minusNanos(1);
+        OffsetDateTime dayStart = date.atStartOfDay(DIARY_ZONE).toOffsetDateTime();
+        OffsetDateTime dayEnd = date.plusDays(1).atStartOfDay(DIARY_ZONE).toOffsetDateTime().minusNanos(1);
 
         GrowthMeasurement growthMeasurement = growthMeasurementRepository
                 .findTopByCrops_CropsIdAndMeasuredAtBetweenOrderByMeasuredAtDesc(cropsId, dayStart, dayEnd)
+                .orElse(null);
+
+        VisionInference diseaseInference = visionInferenceRepository
+                .findLatestByFarmIdAndTaskTypeAndCapturedAtBetween(
+                        farmId,
+                        TASK_DISEASE_CLASSIFICATION,
+                        dayStart,
+                        dayEnd
+                )
+                .orElse(null);
+
+        VisionInference growthInference = visionInferenceRepository
+                .findLatestByFarmIdAndTaskTypeAndCapturedAtBetween(
+                        farmId,
+                        TASK_GROWTH_MEASUREMENT,
+                        dayStart,
+                        dayEnd
+                )
                 .orElse(null);
 
         CropGddDaily gddDaily = cropGddDailyRepository
                 .findByCrops_CropsIdAndTargetDate(cropsId, date)
                 .orElse(null);
 
+        String imageUrl = resolveImageUrl(diseaseInference, growthInference);
+        GrowthDiaryDetailResponse.Temperature temperature = toTemperature(farmId, dayStart, dayEnd);
+
         GrowthDiaryDetailResponse.Growth growth = growthMeasurement == null
                 ? null
                 : new GrowthDiaryDetailResponse.Growth(
+                resolveSizeCm(growthMeasurement),
                 growthMeasurement.getLeafCount(),
-                growthMeasurement.getFruitCount(),
-                resolveSizeCm(growthMeasurement)
+                growthMeasurement.getFruitCount()
         );
 
         GrowthDiaryDetailResponse.Gdd gdd = null;
@@ -351,16 +382,17 @@ public class GddSummaryService {
             gdd = new GrowthDiaryDetailResponse.Gdd(gddDaily.getGdd(), cumulative);
         }
 
-        GrowthDiaryDetailResponse.Disease disease = toDisease(growthMeasurement);
+        GrowthDiaryDetailResponse.Disease disease = toDisease(diseaseInference);
 
-        if (growth == null && gdd == null && disease == null) {
+        if (imageUrl == null && temperature == null && growth == null && gdd == null && disease == null) {
             throw new AppException(HttpStatus.NOT_FOUND, "growth diary not found for date");
         }
 
         return new GrowthDiaryDetailResponse(
+                crop.getFarm().getName(),
                 date,
-                null,
-                null,
+                imageUrl,
+                temperature,
                 growth,
                 gdd,
                 disease
@@ -407,19 +439,58 @@ public class GddSummaryService {
         return row.getLeafArea();
     }
 
-    private GrowthDiaryDetailResponse.Disease toDisease(GrowthMeasurement row) {
-        if (row == null || row.getAiConfidence() == null) {
+    private GrowthDiaryDetailResponse.Disease toDisease(VisionInference inference) {
+        if (inference == null) {
             return null;
         }
 
-        String verdict = safeText(row.getAiVerdict());
-        String label = safeText(row.getAiLabel());
-        String diseaseName = verdict != null ? verdict : label;
+        String diseaseName = safeText(inference.getLabel());
         if (diseaseName == null) {
             diseaseName = "unknown";
         }
 
-        return new GrowthDiaryDetailResponse.Disease(diseaseName, row.getAiConfidence());
+        String status = Boolean.TRUE.equals(inference.getIsAbnormal()) || !isHealthyLike(diseaseName)
+                ? "ABNORMAL"
+                : "NORMAL";
+        return new GrowthDiaryDetailResponse.Disease(status, diseaseName, inference.getConfidence());
+    }
+
+    private String resolveImageUrl(VisionInference diseaseInference, VisionInference growthInference) {
+        String diseaseImageUrl = imageUrlOf(diseaseInference);
+        if (diseaseImageUrl != null) {
+            return diseaseImageUrl;
+        }
+        return imageUrlOf(growthInference);
+    }
+
+    private String imageUrlOf(VisionInference inference) {
+        if (inference == null || inference.getCapture() == null) {
+            return null;
+        }
+        return safeText(inference.getCapture().getImagePath());
+    }
+
+    private GrowthDiaryDetailResponse.Temperature toTemperature(
+            Long farmId,
+            OffsetDateTime dayStart,
+            OffsetDateTime dayEnd
+    ) {
+        List<BigDecimal> values = sensorReadingRepository.findDailyValuesByFarmIdAndSensorType(
+                farmId,
+                SensorType.SOIL_TEMPERATURE,
+                dayStart,
+                dayEnd
+        );
+        if (values.isEmpty()) {
+            return null;
+        }
+
+        BigDecimal min = values.stream().min(BigDecimal::compareTo).orElse(null);
+        BigDecimal max = values.stream().max(BigDecimal::compareTo).orElse(null);
+        BigDecimal sum = values.stream().reduce(BigDecimal.ZERO, BigDecimal::add);
+        BigDecimal avg = sum.divide(BigDecimal.valueOf(values.size()), 1, RoundingMode.HALF_UP);
+
+        return new GrowthDiaryDetailResponse.Temperature(min, max, avg);
     }
 
     private String safeText(String value) {

--- a/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
+++ b/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
@@ -57,6 +57,11 @@ public class VisionInferenceService {
     private static final String TASK_DISEASE_CLASSIFICATION = "DISEASE_CLASSIFICATION";
     private static final String TASK_GROWTH_MEASUREMENT = "GROWTH_MEASUREMENT";
     private static final BigDecimal GROWTH_CONFIDENCE_THRESHOLD = BigDecimal.valueOf(0.6);
+    private static final Map<Integer, Integer> DISEASE_TO_GROWTH_CROP_CODE = Map.of(
+            2, 6,
+            3, 4,
+            5, 5
+    );
 
     private final FarmMemberRepository farmMemberRepository;
     private final CropsRepository cropsRepository;
@@ -141,6 +146,67 @@ public class VisionInferenceService {
     }
 
     @Transactional
+    public DiseaseCheckData inferScheduledDiseaseAndSave(
+            Long farmId,
+            Long cropsId,
+            byte[] imageBytes,
+            String originalFilename,
+            String contentType,
+            Long cameraId,
+            Long captureId,
+            OffsetDateTime measuredAt
+    ) {
+        Crops crop = cropsRepository.findByFarmIdAndCropsIdWithGrowthStandard(farmId, cropsId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "crops not found in farm"));
+        Integer cropCode = parseCropCode(crop);
+
+        PreparedInferenceContext prepared = prepareCapturedInference(
+                crop,
+                imageBytes,
+                originalFilename,
+                contentType,
+                cameraId,
+                captureId,
+                TASK_DISEASE_CLASSIFICATION,
+                cropCode,
+                measuredAt
+        );
+        VisionInference inference = saveVisionInference(prepared.uploadedImage(), prepared.aiResponse());
+        return toCheckData(prepared.uploadedImage(), inference, prepared.aiResponse());
+    }
+
+    @Transactional
+    public GrowthCheckData inferScheduledGrowthAndSave(
+            Long farmId,
+            Long cropsId,
+            byte[] imageBytes,
+            String originalFilename,
+            String contentType,
+            Long cameraId,
+            Long captureId,
+            OffsetDateTime measuredAt
+    ) {
+        Crops crop = cropsRepository.findByFarmIdAndCropsIdWithGrowthStandard(farmId, cropsId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "crops not found in farm"));
+        Integer cropCode = parseScheduledGrowthCropCode(crop);
+
+        PreparedInferenceContext prepared = prepareCapturedInference(
+                crop,
+                imageBytes,
+                originalFilename,
+                contentType,
+                cameraId,
+                captureId,
+                TASK_GROWTH_MEASUREMENT,
+                cropCode,
+                measuredAt
+        );
+        VisionInference inference = saveVisionInference(prepared.uploadedImage(), prepared.aiResponse());
+        saveGrowthMeasurement(prepared.crop(), prepared.capturedAt(), prepared.aiResponse());
+        return toGrowthCheckData(prepared.uploadedImage(), inference, prepared.aiResponse());
+    }
+
+    @Transactional
     private PreparedInferenceContext prepareInference(
             Long farmId,
             Long cropsId,
@@ -185,6 +251,45 @@ public class VisionInferenceService {
         );
 
         return new PreparedInferenceContext(crop, capturedAt, uploadedImage, aiResponse);
+    }
+
+    private PreparedInferenceContext prepareCapturedInference(
+            Crops crop,
+            byte[] imageBytes,
+            String originalFilename,
+            String contentType,
+            Long cameraId,
+            Long captureId,
+            String taskType,
+            Integer cropCode,
+            OffsetDateTime measuredAt
+    ) {
+        if (imageBytes == null || imageBytes.length == 0) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "image is required");
+        }
+
+        ImageCapture capturedImage = imageCaptureRepository.findById(captureId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "image capture not found"));
+        if (cameraId != null && capturedImage.getCameraId() != null && !capturedImage.getCameraId().equals(cameraId)) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "cameraId does not match image capture");
+        }
+
+        String requestedTaskType = normalizeTaskType(taskType);
+        validateTaskInputs(requestedTaskType, cropCode);
+        AiPredictResponse aiResponse = callAiServer(
+                imageBytes,
+                originalFilename,
+                contentType,
+                capturedImage.getCaptureId(),
+                requestedTaskType,
+                cropCode
+        );
+
+        OffsetDateTime capturedAt = measuredAt == null ? capturedImage.getCapturedAt() : measuredAt;
+        if (capturedAt == null) {
+            capturedAt = OffsetDateTime.now(ZoneOffset.UTC);
+        }
+        return new PreparedInferenceContext(crop, capturedAt, capturedImage, aiResponse);
     }
 
     private VisionInference saveVisionInference(ImageCapture uploadedImage, AiPredictResponse aiResponse) {
@@ -676,6 +781,37 @@ public class VisionInferenceService {
         } catch (NumberFormatException e) {
             throw new AppException(HttpStatus.BAD_REQUEST, "invalid cropCode configured for crop");
         }
+    }
+
+    private Integer parseScheduledGrowthCropCode(Crops crop) {
+        Integer diseaseCropCode = parseCropCode(crop);
+        Integer mappedCropCode = DISEASE_TO_GROWTH_CROP_CODE.get(diseaseCropCode);
+        if (mappedCropCode != null) {
+            return mappedCropCode;
+        }
+
+        String cropName = crop.getName() == null ? "" : crop.getName().trim().toLowerCase(Locale.ROOT);
+        if (cropName.contains("양배추") || cropName.contains("cabbage")) {
+            return 1;
+        }
+        if (cropName.contains("상추") || cropName.contains("lettuce")) {
+            return 2;
+        }
+        if (cropName.contains("배추") || cropName.contains("napa")) {
+            return 3;
+        }
+        if (cropName.contains("파프리카") || cropName.contains("paprika")) {
+            return 4;
+        }
+        if (cropName.contains("고추") || cropName.contains("pepper")) {
+            return 5;
+        }
+        if (cropName.contains("토마토") || cropName.contains("tomato")) {
+            return 6;
+        }
+
+        throw new AppException(HttpStatus.BAD_REQUEST,
+                "growth model cropCode is not supported for cropCode=" + diseaseCropCode);
     }
 
     private record PreparedInferenceContext(

--- a/src/main/java/com/example/practice/service/device/DeviceService.java
+++ b/src/main/java/com/example/practice/service/device/DeviceService.java
@@ -32,7 +32,8 @@ public class DeviceService {
         return deviceRepository.findByDeviceUuid(request.getDeviceUuid())
                 .map(existing -> {
                     existing.moveFarm(request.getFarmId());
-                    return DeviceResponse.from(existing);
+                    Camera camera = findPrimaryCamera(existing);
+                    return DeviceResponse.from(existing, camera);
                 })
                 .orElseGet(() -> {
                     // 신규 등록일 때만 카메라 생성
@@ -109,6 +110,12 @@ public class DeviceService {
                 primary
         );
         return cameraRepository.save(camera);
+    }
+
+    private Camera findPrimaryCamera(Device device) {
+        return cameraRepository.findFirstByDevice_DeviceIdAndPrimaryTrueOrderByCameraIdAsc(device.getDeviceId())
+                .or(() -> cameraRepository.findFirstByDevice_DeviceIdOrderByPrimaryDescCameraIdAsc(device.getDeviceId()))
+                .orElse(null);
     }
 
     private String defaultCameraName(String deviceName) {

--- a/src/main/java/com/example/practice/service/schedule/CameraCaptureInferenceService.java
+++ b/src/main/java/com/example/practice/service/schedule/CameraCaptureInferenceService.java
@@ -1,0 +1,216 @@
+package com.example.practice.service.schedule;
+
+import com.example.practice.common.error.AppException;
+import com.example.practice.dto.crops.DiseaseCheckData;
+import com.example.practice.dto.crops.GrowthCheckData;
+import com.example.practice.dto.farm.CameraCaptureResponse;
+import com.example.practice.entity.crops.Crops;
+import com.example.practice.repository.crops.CropsRepository;
+import com.example.practice.service.crops.VisionInferenceService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
+@Service
+@RequiredArgsConstructor
+public class CameraCaptureInferenceService {
+
+    private static final long IMAGE_DOWNLOAD_TIMEOUT_MS = 10000;
+
+    private final CropsRepository cropsRepository;
+    private final VisionInferenceService visionInferenceService;
+    private final WebClient.Builder webClientBuilder;
+
+    public ScheduledCaptureInferenceResult runAfterCapture(Long farmId, CameraCaptureResponse capture) {
+        Crops crop = resolveCurrentCrop(farmId);
+        CapturedImage image = downloadCapturedImage(capture.imageUrl(), capture.contentType());
+
+        InferenceStepResult disease = runDiseaseInference(farmId, crop, image, capture);
+        InferenceStepResult growth = runGrowthInference(farmId, crop, image, capture);
+
+        return new ScheduledCaptureInferenceResult(
+                crop.getCropsId(),
+                disease.inferenceId(),
+                disease.label(),
+                disease.errorMessage(),
+                growth.inferenceId(),
+                growth.leafCount(),
+                growth.errorMessage()
+        );
+    }
+
+    private InferenceStepResult runDiseaseInference(
+            Long farmId,
+            Crops crop,
+            CapturedImage image,
+            CameraCaptureResponse capture
+    ) {
+        try {
+            DiseaseCheckData disease = visionInferenceService.inferScheduledDiseaseAndSave(
+                    farmId,
+                    crop.getCropsId(),
+                    image.bytes(),
+                    image.filename(),
+                    image.contentType(),
+                    capture.cameraId(),
+                    capture.captureId(),
+                    capture.capturedAt()
+            );
+            return InferenceStepResult.success(disease.inferenceId(), disease.diseaseName(), null);
+        } catch (Exception e) {
+            return InferenceStepResult.failure(toFailureMessage(e));
+        }
+    }
+
+    private InferenceStepResult runGrowthInference(
+            Long farmId,
+            Crops crop,
+            CapturedImage image,
+            CameraCaptureResponse capture
+    ) {
+        try {
+            GrowthCheckData growth = visionInferenceService.inferScheduledGrowthAndSave(
+                    farmId,
+                    crop.getCropsId(),
+                    image.bytes(),
+                    image.filename(),
+                    image.contentType(),
+                    capture.cameraId(),
+                    capture.captureId(),
+                    capture.capturedAt()
+            );
+            return InferenceStepResult.success(growth.inferenceId(), null, growth.leafCount());
+        } catch (Exception e) {
+            return InferenceStepResult.failure(toFailureMessage(e));
+        }
+    }
+
+    private Crops resolveCurrentCrop(Long farmId) {
+        List<Crops> candidates = cropsRepository.findCurrentCropCandidatesByFarmId(farmId);
+        if (candidates.isEmpty()) {
+            throw new AppException(HttpStatus.NOT_FOUND, "current crop not found for farm");
+        }
+        return candidates.get(0);
+    }
+
+    private CapturedImage downloadCapturedImage(String imageUrl, String contentType) {
+        if (imageUrl == null || imageUrl.isBlank()) {
+            throw new AppException(HttpStatus.BAD_REQUEST, "captured image url is empty");
+        }
+
+        byte[] bytes = imageUrl.startsWith("/")
+                ? readLocalImage(imageUrl)
+                : readRemoteImage(imageUrl);
+
+        String filename = filenameFromUrl(imageUrl);
+        String resolvedContentType = contentType == null || contentType.isBlank()
+                ? MediaType.IMAGE_JPEG_VALUE
+                : contentType;
+        return new CapturedImage(bytes, filename, resolvedContentType);
+    }
+
+    private byte[] readLocalImage(String imagePath) {
+        try {
+            return Files.readAllBytes(Path.of(imagePath));
+        } catch (IOException e) {
+            throw new AppException(HttpStatus.BAD_GATEWAY, "failed to read captured image");
+        }
+    }
+
+    private byte[] readRemoteImage(String imageUrl) {
+        try {
+            ByteArrayResource resource = webClientBuilder.build()
+                    .get()
+                    .uri(imageUrl)
+                    .retrieve()
+                    .bodyToMono(ByteArrayResource.class)
+                    .timeout(Duration.ofMillis(IMAGE_DOWNLOAD_TIMEOUT_MS))
+                    .onErrorMap(TimeoutException.class,
+                            ex -> new AppException(HttpStatus.GATEWAY_TIMEOUT, "captured image download timeout"))
+                    .onErrorMap(WebClientRequestException.class,
+                            ex -> new AppException(HttpStatus.SERVICE_UNAVAILABLE, "captured image is unavailable"))
+                    .onErrorMap(WebClientResponseException.class,
+                            ex -> new AppException(HttpStatus.BAD_GATEWAY,
+                                    "captured image download error: " + ex.getStatusCode().value()))
+                    .block();
+
+            if (resource == null || resource.contentLength() == 0) {
+                throw new AppException(HttpStatus.BAD_GATEWAY, "empty captured image");
+            }
+            return resource.getByteArray();
+        } catch (AppException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AppException(HttpStatus.BAD_GATEWAY, "failed to download captured image");
+        }
+    }
+
+    private String filenameFromUrl(String imageUrl) {
+        String normalized = imageUrl;
+        int queryIndex = normalized.indexOf('?');
+        if (queryIndex >= 0) {
+            normalized = normalized.substring(0, queryIndex);
+        }
+        int slashIndex = normalized.lastIndexOf('/');
+        String filename = slashIndex >= 0 ? normalized.substring(slashIndex + 1) : normalized;
+        return filename.isBlank() ? "scheduled-capture.jpg" : filename;
+    }
+
+    private String toFailureMessage(Exception e) {
+        if (e.getMessage() == null || e.getMessage().isBlank()) {
+            return e.getClass().getSimpleName();
+        }
+        return e.getMessage();
+    }
+
+    private record CapturedImage(byte[] bytes, String filename, String contentType) {
+    }
+
+    private record InferenceStepResult(Long inferenceId, String label, Integer leafCount, String errorMessage) {
+        private static InferenceStepResult success(Long inferenceId, String label, Integer leafCount) {
+            return new InferenceStepResult(inferenceId, label, leafCount, null);
+        }
+
+        private static InferenceStepResult failure(String errorMessage) {
+            return new InferenceStepResult(null, null, null, errorMessage);
+        }
+    }
+
+    public record ScheduledCaptureInferenceResult(
+            Long cropsId,
+            Long diseaseInferenceId,
+            String diseaseName,
+            String diseaseErrorMessage,
+            Long growthInferenceId,
+            Integer leafCount,
+            String growthErrorMessage
+    ) {
+        public boolean hasFailures() {
+            return diseaseErrorMessage != null || growthErrorMessage != null;
+        }
+
+        public String toHistoryMessage(Long captureId) {
+            return "camera capture and inference " + (hasFailures() ? "partial failure" : "success")
+                    + ": captureId=" + captureId
+                    + ", cropsId=" + cropsId
+                    + ", diseaseInferenceId=" + diseaseInferenceId
+                    + ", diseaseName=" + diseaseName
+                    + ", diseaseError=" + diseaseErrorMessage
+                    + ", growthInferenceId=" + growthInferenceId
+                    + ", leafCount=" + leafCount
+                    + ", growthError=" + growthErrorMessage;
+        }
+    }
+}

--- a/src/main/java/com/example/practice/service/schedule/CameraScheduleExecutorService.java
+++ b/src/main/java/com/example/practice/service/schedule/CameraScheduleExecutorService.java
@@ -15,7 +15,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -33,12 +32,12 @@ public class CameraScheduleExecutorService {
     private final AutomationScheduleRepository automationScheduleRepository;
     private final ScheduleExecutionHistoryRepository scheduleExecutionHistoryRepository;
     private final FarmCameraService farmCameraService;
+    private final CameraCaptureInferenceService cameraCaptureInferenceService;
 
     @Value("${camera.scheduler.zone-id:Asia/Seoul}")
     private String zoneId;
 
     @Scheduled(cron = "${camera.scheduler.cron:0 * * * * *}")
-    @Transactional
     public void executeDueCameraSchedules() {
         ZoneId schedulerZone = ZoneId.of(zoneId);
         LocalDateTime now = LocalDateTime.now(schedulerZone).withSecond(0).withNano(0);
@@ -82,12 +81,16 @@ public class CameraScheduleExecutorService {
 
         try {
             CameraCaptureResponse capture = farmCameraService.captureFarmCameraForSchedule(schedule.getFarmId(), null);
-            schedule.updateLastExecution(executedAt, ExecutionStatus.SUCCESS);
+            CameraCaptureInferenceService.ScheduledCaptureInferenceResult inferenceResult =
+                    cameraCaptureInferenceService.runAfterCapture(schedule.getFarmId(), capture);
+            ExecutionStatus status = inferenceResult.hasFailures() ? ExecutionStatus.ERROR : ExecutionStatus.SUCCESS;
+            schedule.updateLastExecution(executedAt, status);
+            automationScheduleRepository.save(schedule);
             scheduleExecutionHistoryRepository.save(ScheduleExecutionHistory.create(
                     schedule,
                     executedAt.withOffsetSameInstant(ZoneOffset.UTC),
-                    ExecutionStatus.SUCCESS,
-                    "camera capture success: captureId=" + capture.captureId(),
+                    status,
+                    inferenceResult.toHistoryMessage(capture.captureId()),
                     null,
                     schedule.getTimeRule() != null ? schedule.getTimeRule().getDurationMinutes() : null
             ));
@@ -95,6 +98,7 @@ public class CameraScheduleExecutorService {
             log.warn("Camera schedule execution failed. scheduleId={} farmId={} message={}",
                     schedule.getScheduleId(), schedule.getFarmId(), ex.getMessage());
             schedule.updateLastExecution(executedAt, ExecutionStatus.ERROR);
+            automationScheduleRepository.save(schedule);
             scheduleExecutionHistoryRepository.save(ScheduleExecutionHistory.create(
                     schedule,
                     executedAt.withOffsetSameInstant(ZoneOffset.UTC),


### PR DESCRIPTION
### 변경 사항
- 카메라 스케줄러 추가
  - 매일 오전 8시 카메라 촬영 스케줄 실행
  - 촬영 이미지 저장 및 스케줄 실행 이력 기록

- 카메라 촬영 후 AI 추론 자동 실행
  - 병해충 모델 추론 결과를 `vision_inference`에 저장
  - 생장 모델 추론 결과를 `vision_inference`, `growth_measurement`에 저장
  - 병해충 crop code 기준으로 생장 모델 crop code 자동 매핑
  - 모델 미지원 작물 또는 추론 실패 시 partial failure로 기록

- 성장일기 상세 API 응답 확장
  - 농장 이름, 날짜, 사진, 온도 정보 추가
  - 병해충 결과 및 신뢰도 추가
  - 작물 크기, 잎 개수, 열매 개수 추가
  - 일별/누적 GDD 추가

- 성장일기 월별 API 응답 수정
  - 월/일/날짜별 GDD 목록 반환

- GPT 설문 기반 작물 추천 API 추가
  - `POST /api/v1/crops-recommend/ai`
  - 지역, 재배 장소, 관리 시간, 재배 목적, 수확 주기 기반 추천
  - GPT 호출 실패 시 fallback 추천 반환

