### PR TITLE
[feat] 카메라 MJPEG 스트리밍 및 최근 캡처 병해충 추론 API 추가

### DIFF
--- a/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
+++ b/src/main/java/com/example/practice/controller/crops/FarmCropVisionController.java
@@ -57,6 +57,23 @@ public class FarmCropVisionController {
         );
     }
 
+    @Operation(summary = "최근 캡처 사진으로 병해충 추론", description = "DB에 저장된 가장 최근 캡처 이미지로 병해충 추론 후 저장합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "추론 및 저장 성공"),
+            @ApiResponse(responseCode = "404", description = "캡처 이미지 없음"),
+            @ApiResponse(responseCode = "502", description = "AI 서버 응답 오류"),
+            @ApiResponse(responseCode = "503", description = "AI 서버 연결 실패"),
+            @ApiResponse(responseCode = "504", description = "AI 서버 타임아웃")
+    })
+    @PostMapping("/{farmId}/crops/{cropsId}/vision-inference/latest-capture")
+    public VisionInferenceCheckResponse inferFromLatestCapture(
+            @PathVariable Long farmId,
+            @PathVariable Long cropsId,
+            @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
+    ) {
+        return visionInferenceService.inferDiseaseFromLatestCapture(farmId, cropsId, user.id());
+    }
+
     @Operation(summary = "작물 이미지 생장 추론", description = "이미지를 AI 서버로 전달해 생장 추론 후 DB에 저장합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "추론 및 저장 성공"),

--- a/src/main/java/com/example/practice/dto/farm/CameraStreamResponse.java
+++ b/src/main/java/com/example/practice/dto/farm/CameraStreamResponse.java
@@ -1,12 +1,9 @@
 package com.example.practice.dto.farm;
 
-import java.time.OffsetDateTime;
-
 public record CameraStreamResponse(
         Long cameraId,
         String cameraName,
         String streamUrl,
-        String protocol,
-        OffsetDateTime expiresAt
+        String protocol
 ) {
 }

--- a/src/main/java/com/example/practice/repository/crops/ImageCaptureRepository.java
+++ b/src/main/java/com/example/practice/repository/crops/ImageCaptureRepository.java
@@ -2,10 +2,23 @@ package com.example.practice.repository.crops;
 
 import com.example.practice.entity.crops.ImageCapture;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ImageCaptureRepository extends JpaRepository<ImageCapture, Long> {
 
     void deleteAllByCameraIdIn(List<Long> cameraIds);
+
+    @Query("""
+            SELECT ic FROM ImageCapture ic
+            JOIN Camera c ON ic.cameraId = c.cameraId
+            JOIN Device d ON c.device.deviceId = d.deviceId
+            WHERE d.farmId = :farmId
+            ORDER BY ic.capturedAt DESC
+            LIMIT 1
+            """)
+    Optional<ImageCapture> findLatestByFarmId(@Param("farmId") Long farmId);
 }

--- a/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
+++ b/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
@@ -92,6 +92,45 @@ public class VisionInferenceService {
     );
 
     @Transactional
+    public VisionInferenceCheckResponse inferDiseaseFromLatestCapture(
+            Long farmId,
+            Long cropsId,
+            Long userId
+    ) {
+        if (!farmMemberRepository.existsByFarmIdAndUserId(farmId, userId)) {
+            throw new AppException(HttpStatus.FORBIDDEN, "farm access denied");
+        }
+
+        ImageCapture latestCapture = imageCaptureRepository.findLatestByFarmId(farmId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "no captured image found for farm"));
+
+        Crops crop = cropsRepository.findByFarmIdAndCropsIdWithGrowthStandard(farmId, cropsId)
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "crops not found in farm"));
+        Integer cropCode = parseCropCode(crop);
+
+        byte[] imageBytes = latestCapture.getImagePath().startsWith("/")
+                ? readLocalImage(latestCapture.getImagePath())
+                : readRemoteImage(latestCapture.getImagePath());
+
+        String filename = filenameFromPath(latestCapture.getImagePath());
+
+        PreparedInferenceContext prepared = prepareCapturedInference(
+                crop,
+                imageBytes,
+                filename,
+                MediaType.IMAGE_JPEG_VALUE,
+                latestCapture.getCameraId(),
+                latestCapture.getCaptureId(),
+                TASK_DISEASE_CLASSIFICATION,
+                cropCode,
+                latestCapture.getCapturedAt()
+        );
+        VisionInference inference = saveVisionInference(prepared.uploadedImage(), prepared.aiResponse());
+        DiseaseCheckData data = toCheckData(prepared.uploadedImage(), inference, prepared.aiResponse());
+        return VisionInferenceCheckResponse.ok(data);
+    }
+
+    @Transactional
     public VisionInferenceCheckResponse inferDiseaseAndSave(
             Long farmId,
             Long cropsId,
@@ -840,6 +879,52 @@ public class VisionInferenceService {
             throw new AppException(HttpStatus.INTERNAL_SERVER_ERROR, "failed to save capture image");
         }
         return target.getAbsolutePath();
+    }
+
+    private byte[] readLocalImage(String imagePath) {
+        try {
+            return java.nio.file.Files.readAllBytes(java.nio.file.Path.of(imagePath));
+        } catch (IOException e) {
+            throw new AppException(HttpStatus.BAD_GATEWAY, "failed to read captured image");
+        }
+    }
+
+    private byte[] readRemoteImage(String imageUrl) {
+        try {
+            ByteArrayResource resource = webClientBuilder.build()
+                    .get()
+                    .uri(imageUrl)
+                    .retrieve()
+                    .bodyToMono(ByteArrayResource.class)
+                    .timeout(Duration.ofMillis(Math.max(aiTimeoutMs, 1000)))
+                    .onErrorMap(TimeoutException.class,
+                            ex -> new AppException(HttpStatus.GATEWAY_TIMEOUT, "captured image download timeout"))
+                    .onErrorMap(WebClientRequestException.class,
+                            ex -> new AppException(HttpStatus.SERVICE_UNAVAILABLE, "captured image is unavailable"))
+                    .onErrorMap(WebClientResponseException.class,
+                            ex -> new AppException(HttpStatus.BAD_GATEWAY,
+                                    "captured image download error: " + ex.getStatusCode().value()))
+                    .block();
+
+            if (resource == null || resource.contentLength() == 0) {
+                throw new AppException(HttpStatus.BAD_GATEWAY, "empty captured image");
+            }
+            return resource.getByteArray();
+        } catch (AppException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new AppException(HttpStatus.BAD_GATEWAY, "failed to download captured image");
+        }
+    }
+
+    private String filenameFromPath(String path) {
+        if (path == null || path.isBlank()) {
+            return "capture.jpg";
+        }
+        String normalized = path.contains("?") ? path.substring(0, path.indexOf('?')) : path;
+        int slash = normalized.lastIndexOf('/');
+        String name = slash >= 0 ? normalized.substring(slash + 1) : normalized;
+        return name.isBlank() ? "capture.jpg" : name;
     }
 
     private byte[] readUploadedImage(MultipartFile image) {

--- a/src/main/java/com/example/practice/service/farm/FarmCameraService.java
+++ b/src/main/java/com/example/practice/service/farm/FarmCameraService.java
@@ -45,12 +45,6 @@ public class FarmCameraService {
     @Value("${file.upload-dir}")
     private String uploadDir;
 
-    @Value("${camera.stream.playback-base-url:}")
-    private String playbackBaseUrl;
-
-    @Value("${camera.stream.ttl-minutes:60}")
-    private long ttlMinutes;
-
     @Value("${camera.capture.timeout-ms:10000}")
     private long captureTimeoutMs;
 
@@ -64,18 +58,12 @@ public class FarmCameraService {
                 .or(() -> cameraRepository.findFirstByDevice_FarmIdOrderByPrimaryDescCameraIdAsc(farmId))
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for farm"));
 
-        if (playbackBaseUrl == null || playbackBaseUrl.isBlank()) {
-            throw new AppException(HttpStatus.NOT_FOUND, "camera stream not configured for farm");
-        }
-
-        OffsetDateTime expiresAt = OffsetDateTime.now(ZoneOffset.UTC).plusMinutes(Math.max(ttlMinutes, 1));
-        String streamUrl = buildStreamUrl(camera.getStreamKey(), camera.getStreamProtocol());
+        String streamUrl = buildMjpegStreamUrl(camera.getCaptureEndpoint());
         return new CameraStreamResponse(
                 camera.getCameraId(),
                 camera.getName(),
                 streamUrl,
-                camera.getStreamProtocol(),
-                expiresAt
+                "MJPEG"
         );
     }
 
@@ -150,16 +138,14 @@ public class FarmCameraService {
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for device"));
     }
 
-    private String buildStreamUrl(String streamKey, String protocol) {
-        String normalizedBaseUrl = playbackBaseUrl.endsWith("/")
-                ? playbackBaseUrl.substring(0, playbackBaseUrl.length() - 1)
-                : playbackBaseUrl;
-
-        if ("HLS".equalsIgnoreCase(protocol)) {
-            return normalizedBaseUrl + "/" + streamKey + "/index.m3u8";
+    private String buildMjpegStreamUrl(String captureEndpoint) {
+        if (captureEndpoint == null || captureEndpoint.isBlank()) {
+            throw new AppException(HttpStatus.NOT_FOUND, "camera stream not configured");
         }
-
-        return normalizedBaseUrl + "/" + streamKey;
+        // captureEndpoint 예: http://192.168.45.135:8000/capture → /stream 으로 교체
+        int lastSlash = captureEndpoint.lastIndexOf('/');
+        String base = lastSlash >= 0 ? captureEndpoint.substring(0, lastSlash) : captureEndpoint;
+        return base + "/stream";
     }
 
     private byte[] requestCapture(String captureEndpoint) {


### PR DESCRIPTION
## Summary
라즈베리파이 카메라 서버에 MJPEG 실시간 스트리밍 엔드포인트 추가
농장 카메라 스트리밍 URL 반환 방식을 captureEndpoint 기반으로 변경
DB에 저장된 가장 최근 캡처 사진으로 병해충 추론하는 API 추가

## Changes
라즈베리파이 (capture_server.py)
- GET /stream — ffmpeg으로 카메라 연속 프레임을 multipart/x-mixed-replace 형식으로 스트리밍

## Spring Boot

FarmCameraService — 스트리밍 URL을 captureEndpoint 기반 MJPEG URL로 반환하도록 변경, 불필요한 playbackBaseUrl, ttlMinutes 설정 제거
CameraStreamResponse — 불필요한 expiresAt 필드 제거
ImageCaptureRepository — findLatestByFarmId() 농장 기준 최근 캡처 조회 쿼리 추가
VisionInferenceService — inferDiseaseFromLatestCapture() 최근 캡처 기반 병해충 추론 메서드 추가
POST /api/v1/farms/{farmId}/crops/{cropsId}/vision-inference/latest-capture 엔드포인트 추가
