### PR TITLE
[feat] 카메라 스트리밍 프록시 및 WebClient 버그 수정

### DIFF
--- a/src/main/java/com/example/practice/controller/farm/FarmCameraController.java
+++ b/src/main/java/com/example/practice/controller/farm/FarmCameraController.java
@@ -8,6 +8,8 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,6 +17,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.StreamingResponseBody;
 
 @Tag(name = "Farm Camera", description = "농장 카메라 스트리밍 API")
 @SecurityRequirement(name = "JWT")
@@ -32,6 +35,20 @@ public class FarmCameraController {
             @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
     ) {
         return farmCameraService.getFarmCameraStream(farmId, user.id());
+    }
+
+    @Operation(summary = "카메라 실시간 스트리밍 프록시", description = "Spring Boot 서버를 통해 라즈베리파이 MJPEG 스트림을 중계합니다.")
+    @GetMapping("/{farmId}/camera/stream-proxy")
+    public ResponseEntity<StreamingResponseBody> streamProxy(
+            @PathVariable Long farmId,
+            @AuthenticationPrincipal TokenAuthFilter.UserPrincipal user
+    ) {
+        StreamingResponseBody body = outputStream ->
+                farmCameraService.proxyFarmCameraStream(farmId, user.id(), outputStream);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.parseMediaType("multipart/x-mixed-replace; boundary=frame"))
+                .body(body);
     }
 
     @Operation(summary = "카메라 캡처", description = "farm에 연결된 카메라에서 현재 이미지를 캡처해 저장합니다.")

--- a/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
+++ b/src/main/java/com/example/practice/service/crops/VisionInferenceService.java
@@ -463,7 +463,7 @@ public class VisionInferenceService {
                 bodyBuilder.part("crop_code", cropCode);
             }
 
-            JsonNode rawResponse = webClientBuilder.baseUrl(aiBaseUrl).build()
+            JsonNode rawResponse = webClientBuilder.clone().baseUrl(aiBaseUrl).build()
                     .post()
                     .uri(aiPredictPath)
                     .contentType(MediaType.MULTIPART_FORM_DATA)
@@ -891,7 +891,7 @@ public class VisionInferenceService {
 
     private byte[] readRemoteImage(String imageUrl) {
         try {
-            ByteArrayResource resource = webClientBuilder.build()
+            ByteArrayResource resource = WebClient.create()
                     .get()
                     .uri(imageUrl)
                     .retrieve()

--- a/src/main/java/com/example/practice/service/farm/FarmCameraService.java
+++ b/src/main/java/com/example/practice/service/farm/FarmCameraService.java
@@ -24,6 +24,10 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -136,6 +140,47 @@ public class FarmCameraService {
         return cameraRepository.findFirstByDevice_DeviceIdAndPrimaryTrueOrderByCameraIdAsc(deviceId)
                 .or(() -> cameraRepository.findFirstByDevice_DeviceIdOrderByPrimaryDescCameraIdAsc(deviceId))
                 .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for device"));
+    }
+
+    public void proxyFarmCameraStream(Long farmId, Long userId, OutputStream outputStream) {
+        if (!farmMemberRepository.existsByFarmIdAndUserId(farmId, userId)) {
+            throw new AppException(HttpStatus.FORBIDDEN, "farm access denied");
+        }
+
+        Camera camera = cameraRepository.findFirstByDevice_FarmIdAndPrimaryTrueOrderByCameraIdAsc(farmId)
+                .or(() -> cameraRepository.findFirstByDevice_FarmIdOrderByPrimaryDescCameraIdAsc(farmId))
+                .orElseThrow(() -> new AppException(HttpStatus.NOT_FOUND, "camera not configured for farm"));
+
+        String streamUrl = buildMjpegStreamUrl(camera.getCaptureEndpoint());
+
+        HttpURLConnection conn = null;
+        try {
+            conn = (HttpURLConnection) new URL(streamUrl).openConnection();
+            conn.setConnectTimeout(5000);
+            conn.setReadTimeout(0);
+            conn.connect();
+
+            if (conn.getResponseCode() != HttpURLConnection.HTTP_OK) {
+                throw new AppException(HttpStatus.BAD_GATEWAY, "camera stream unavailable");
+            }
+
+            try (InputStream in = conn.getInputStream()) {
+                byte[] buffer = new byte[4096];
+                int bytesRead;
+                while ((bytesRead = in.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, bytesRead);
+                    outputStream.flush();
+                }
+            }
+        } catch (AppException e) {
+            throw e;
+        } catch (IOException e) {
+            // 클라이언트 연결 종료 시 정상 종료
+        } finally {
+            if (conn != null) {
+                conn.disconnect();
+            }
+        }
     }
 
     private String buildMjpegStreamUrl(String captureEndpoint) {


### PR DESCRIPTION
#127 

# Summary
- Spring Boot 서버를 통해 라즈베리파이 MJPEG 스트림을 외부에 중계하는 프록시 API 추가
- WebClient 공유 빌더 오염으로 인한 이미지 다운로드 버그 수정

# Changes
- feat: 카메라 MJPEG 스트리밍 프록시 API 추가
  - GET /api/v1/farms/{farmId}/camera/stream-proxy 엔드포인트 추가
  - Spring Boot가 라즈베리파이 Tailscale IP의 MJPEG 스트림을 받아 클라이언트에 중계
  - 앱 사용자가 Tailscale 없이 외부에서 실시간 스트리밍 접근 가능
- fix: WebClient 공유 빌더 오염으로 인한 이미지 다운로드 오류 수정
  - callAiServer()에서 webClientBuilder.clone()으로 원본 빌더 보호
  - readRemoteImage()에서 WebClient.create()로 독립 클라이언트 사용
  - 기존에는 AI 서버 URL이 공유 빌더에 박혀 S3 이미지 다운로드 시 AI 서버로 요청이 가는 잠재적 버그 존재
